### PR TITLE
Add deployment files and other changes to support enabling Hora in OPA Gatekeeper

### DIFF
--- a/cmd/hora/cmd/discover.go
+++ b/cmd/hora/cmd/discover.go
@@ -1,0 +1,107 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/deislabs/hora/config"
+	"github.com/deislabs/hora/pkg/ocispecs"
+	sf "github.com/deislabs/hora/pkg/referrerstore/factory"
+	"github.com/deislabs/hora/pkg/utils"
+	"github.com/spf13/cobra"
+	"github.com/xlab/treeprint"
+)
+
+const (
+	discoverUse = "discover"
+)
+
+type discoverCmdOptions struct {
+	configFilePath string
+	subject        string
+	artifactTypes  []string
+	digest         string
+	storeName      string
+	flatOutput     bool
+}
+
+func NewCmdDiscover(argv ...string) *cobra.Command {
+
+	if len(argv) == 0 {
+		argv = []string{os.Args[0]}
+	}
+
+	eg := fmt.Sprintf(`  # List referrers for a subject
+  %s discover -c ./config.yaml -s myregistry/myrepo@sha256:34343`, strings.Join(argv, " "))
+
+	var opts discoverCmdOptions
+
+	cmd := &cobra.Command{
+		Use:     discoverUse,
+		Short:   "Discover referrers for a subject",
+		Example: eg,
+		Args:    cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			discover(opts)
+		},
+	}
+
+	flags := cmd.Flags()
+
+	flags.StringVarP(&opts.subject, "subject", "s", "", "Subject Reference")
+	flags.StringVarP(&opts.configFilePath, "config", "c", "", "Config File Path")
+	flags.StringArrayVarP(&opts.artifactTypes, "artifactType", "t", nil, "artifact type to filter")
+	flags.BoolVar(&opts.flatOutput, "flat", false, "Output referrers in a flat list format (default is tree format)")
+	return cmd
+}
+
+func discover(opts discoverCmdOptions) error {
+
+	if opts.subject == "" {
+		return errors.New("subject parameter is required")
+	}
+
+	subRef, err := utils.ParseSubjectReference(opts.subject)
+	if err != nil {
+		return err
+	}
+
+	cf, err := config.Load(opts.configFilePath)
+	if err != nil {
+		return err
+	}
+
+	// TODO replace with code
+	rootImage := treeprint.NewWithRoot(subRef.String())
+
+	stores, err := sf.CreateStoresFromConfig(cf.StoresConfig, config.GetDefaultPluginPath())
+
+	if err != nil {
+		return err
+	}
+
+	type Result struct {
+		Name       string
+		References []ocispecs.ReferenceDescriptor
+	}
+
+	var results []listResult
+
+	for _, referrerStore := range stores {
+		storeNode := rootImage.AddBranch(referrerStore.Name())
+		result, err := listReferrersForStore(subRef, opts.artifactTypes, referrerStore, storeNode)
+		if err != nil {
+			return err
+		}
+		results = append(results, *result)
+	}
+
+	if !opts.flatOutput {
+		fmt.Println(rootImage.String())
+		return nil
+	}
+
+	return PrintJSON(results)
+}

--- a/cmd/hora/cmd/root.go
+++ b/cmd/hora/cmd/root.go
@@ -22,6 +22,9 @@ func New(use, short string) *cobra.Command {
 
 	root.AddCommand(NewCmdReferrer(use, referrerUse))
 	root.AddCommand(NewCmdVerify(use, verifyUse))
+	root.AddCommand(NewCmdServe(use, serveUse))
+	root.AddCommand(NewCmdDiscover(use, discoverUse))
+
 	// TODO debug logging
 	return root
 }

--- a/cmd/hora/cmd/serve.go
+++ b/cmd/hora/cmd/serve.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/deislabs/hora/config"
+	"github.com/deislabs/hora/httpserver"
+	ef "github.com/deislabs/hora/pkg/executor/core"
+	pf "github.com/deislabs/hora/pkg/policyprovider/configpolicy"
+	sf "github.com/deislabs/hora/pkg/referrerstore/factory"
+	vf "github.com/deislabs/hora/pkg/verifier/factory"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+const (
+	serveUse = "serve"
+)
+
+type serveCmdOptions struct {
+	configFilePath    string
+	httpServerAddress string
+}
+
+func NewCmdServe(argv ...string) *cobra.Command {
+
+	var opts serveCmdOptions
+
+	cmd := &cobra.Command{
+		Use:     serveUse,
+		Short:   "Run hora as a server",
+		Example: "hora server",
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return serve(opts)
+		},
+	}
+
+	flags := cmd.Flags()
+
+	flags.StringVar(&opts.httpServerAddress, "http", "", "HTTP Address")
+	flags.StringVarP(&opts.configFilePath, "config", "c", "", "Config File Path")
+	return cmd
+}
+
+func serve(opts serveCmdOptions) error {
+	cf, err := config.Load(opts.configFilePath)
+	if err != nil {
+		return err
+	}
+
+	logrus.Info("configuration successfully loaded.")
+	stores, err := sf.CreateStoresFromConfig(cf.StoresConfig, config.GetDefaultPluginPath())
+
+	if err != nil {
+		return err
+	}
+	logrus.Infof("stores successfully created. number of stores %d", len(stores))
+
+	verifiers, err := vf.CreateVerifiersFromConfig(cf.VerifiersConfig, config.GetDefaultPluginPath())
+
+	if err != nil {
+		return err
+	}
+
+	logrus.Infof("verifiers successfully created. number of verifiers %d", len(verifiers))
+
+	executor := ef.Executor{
+		Verifiers:      verifiers,
+		ReferrerStores: stores,
+		PolicyEnforcer: pf.PolicyEnforcer{},
+	}
+
+	if opts.httpServerAddress != "" {
+		server, err := httpserver.NewServer(context.Background(), opts.httpServerAddress, &executor)
+		if err != nil {
+			return err
+		}
+		logrus.Infof("starting server at" + opts.httpServerAddress)
+		if err := server.Run(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/deploy/hora.yaml
+++ b/deploy/hora.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: wabbit-networks-crt
+data:
+  wabbit-networks.crt: <base64 encode of crt file contents>
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hora
+  labels:
+    app: hora
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hora
+  template:
+    metadata:
+      labels:
+        app: hora
+    spec:
+      containers:
+        - name: hora
+          image: deislabs/hora:v1
+          imagePullPolicy: Never #to access the local registry for the image
+          ports:
+            - containerPort: 6001
+          volumeMounts:
+          - mountPath: "/usr/local/wa-certs"
+            name: wabbit-networks-crt
+            readOnly: true
+      volumes:
+        - name: wabbit-networks-crt
+          secret:
+            secretName: wabbit-networks-crt
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hora-svc
+  labels:
+    app: hora
+spec:
+  type: ClusterIP
+  selector:
+    app: hora
+  ports:
+      # By default and for convenience, the `targetPort` is set to the same value as the `port` field.
+    - port: 6001
+      targetPort: 6001

--- a/deploy/policy/constraint.yaml
+++ b/deploy/policy/constraint.yaml
@@ -1,0 +1,10 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sSignedImages
+metadata:
+  name: signed-image
+spec:
+  enforcementAction: deny
+  match:
+    kinds:
+      - apiGroups: ["apps"]
+        kinds: ["Deployment", "Pod"]

--- a/deploy/policy/provider.yaml
+++ b/deploy/policy/provider.yaml
@@ -1,0 +1,9 @@
+apiVersion: externaldata.gatekeeper.sh/v1alpha1
+kind: Provider
+metadata:
+  name: hora-provider
+spec:
+  proxyURL: http://hora-svc.default:6001/hora/v1/verify
+  timeout: 3
+  failurePolicy: Fail
+  maxRetry: 1

--- a/deploy/policy/template.yaml
+++ b/deploy/policy/template.yaml
@@ -1,0 +1,25 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8ssignedimages
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sSignedImages
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8ssignedimages
+        violation[{"msg": msg}] {
+          container := input_containers[_]
+          response := externaldata("hora-provider", container.image)
+          contains(response, "false")
+          msg := sprintf("Image %v verification failed %v", [container.image, response])
+        }
+        input_containers[c] {
+            c := input.review.object.spec.template.spec.containers[_]
+        }
+        input_containers[c] {
+            c := input.review.object.spec.template.spec.initContainers[_]
+        }

--- a/docs/k8s-gatekeeper-provider.md
+++ b/docs/k8s-gatekeeper-provider.md
@@ -1,0 +1,37 @@
+## Hora with OPA Gatekeeper
+This document outlines steps to run Hora as an external data provider to OPA Gatekeeper of Kubernetes. This assumes that OPA Gatekeeper has been deployed to Kubernetes with external data provider feature enabled.
+
+### Setup
+- Setup local Kubernetes cluster. You can use Kubernetes that comes with [Docker Desktop](https://docs.docker.com/desktop/kubernetes/). This will enable access of the local images that are built without the need of pushing them to a remote registry. 
+- Update the ```./config/config.json``` to the certs folder something like ```/usr/local/wa-certs/wabbit-networks.crt```. This will be used to configure the volume mount when Hora is deployed as a k8s service.
+- Build the container image for Hora
+```bash
+docker build -f httpserver/Dockerfile -t deislabs/hora:v1 .
+```
+- Update the secret value in the  [deployment](./deploy/hora.yaml) with base64 encode of the notary cert that will be used for signature verification.
+- Deploy hora as service in k8s
+```bash
+kubectl apply -f deploy/hora.yaml
+```
+- Deploy hora as external data provider for gatekeeper
+
+```bash
+kubectl apply -f deploy/policy/provider.yaml
+```
+
+- Deploy gatekeeper template that invokes Hora as part of admission controller
+```bash
+kubectl apply -f deploy/policy/template.yaml
+```
+
+- Deploy gatekeeper constraint for the policy to be applied for all deployment & pod objects
+```bash
+kubectl apply -f deploy/policy/constraint.yaml
+```
+
+- Now OPA Gatekeeper has been configured to invoke Hora for image verification. 
+- Follow the nv2 demo script to create signed and unsigned images using the same cert that is configured with Hora
+- The deployment of signed image should be success. The deployment of unsigned image should be blocked by admission controller with error 
+```
+Error from server ([signed-image] Image registry.wabbit-networks.io:5000/net-monitor:unsigned@sha256:2179f005cd7701a236d3f574b6c5e92f1783b23552df73995d521a50632ced80 verification failed false): error when creating "unsigned.yaml": admission webhook "validation.gatekeeper.sh" denied the request: [signed-image] Image registry.wabbit-networks.io:5000/net-monitor:unsigned@sha256:2179f005cd7701a236d3f574b6c5e92f1783b23552df73995d521a50632ced80 verification failed false
+```

--- a/go.mod
+++ b/go.mod
@@ -4,14 +4,17 @@ go 1.16
 
 require (
 	github.com/docker/cli v20.10.7+incompatible
+	github.com/docker/distribution v2.7.1+incompatible
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7
 	github.com/google/go-containerregistry v0.6.0
+	github.com/gorilla/mux v1.8.0
 	github.com/notaryproject/notary/v2 v2.0.0-20210414032403-d1367cc13db7
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.1
 	github.com/pkg/errors v0.9.1
 	github.com/sigstore/cosign v1.1.0
 	github.com/sigstore/sigstore v0.0.0-20210729211320-56a91f560f44
+	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.2.1
 	github.com/xlab/treeprint v1.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -807,6 +807,7 @@ github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/mux v1.7.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=

--- a/httpserver/Dockerfile
+++ b/httpserver/Dockerfile
@@ -1,0 +1,30 @@
+FROM golang:alpine3.14 as builder
+
+WORKDIR /app
+
+COPY go.mod .
+
+COPY go.sum .
+
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /app/out/ /app/cmd/hora 
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /app/out/plugins/ /app/plugins/referrerstore/ociregistry
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /app/out/plugins/ /app/plugins/verifier/nv2verifier
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /app/out/plugins/ /app/plugins/verifier/sbom
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /app/out/plugins/ /app/plugins/verifier/cosign
+
+FROM alpine:3.14
+
+RUN set -ex \
+    && apk add --no-cache ca-certificates apache2-utils
+
+ARG HORA_FOLDER=$HOME/.hora/
+COPY --from=builder /app/out/hora /app/
+COPY --from=builder /app/out/plugins ${HORA_FOLDER}/plugins
+COPY --from=builder /app/config/config.json ${HORA_FOLDER}
+ENV HORA_CONFIG=${HORA_FOLDER}
+EXPOSE 6001
+CMD ["./app/hora", "serve", "--http", ":6001"]

--- a/httpserver/context.go
+++ b/httpserver/context.go
@@ -1,0 +1,49 @@
+package httpserver
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/docker/distribution/registry/api/errcode"
+	"github.com/sirupsen/logrus"
+)
+
+type Error struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// ContextHandler defines a http handler with a context input
+type ContextHandler func(ctx context.Context, w http.ResponseWriter, r *http.Request) error
+
+// contextHandler is http handler wrappered by a context
+type contextHandler struct {
+	context context.Context
+	handler ContextHandler
+}
+
+// ServeHTTP serves an HTTP request and implements the http.Handler interface.
+func (ch *contextHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	logrus.Infof("received request %v %v ", r.Method, r.URL)
+	if err := ch.handler(ch.context, w, r); err != nil {
+		logrus.Errorf("request %v %v failed with error %v", r.Method, r.URL, err)
+		if serveErr := errcode.ServeJSON(w, err); serveErr != nil {
+			// TODO log the error
+			logrus.Errorf("request %v %v failed to send with error  %v", r.Method, r.URL, serveErr)
+		}
+	}
+}
+
+func serveErrorJSON(w http.ResponseWriter, err error) error {
+	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	errObj := Error{
+		Code:    "UNKNOWN",
+		Message: err.Error(),
+	}
+	if err := json.NewEncoder(w).Encode(errObj); err != nil {
+		return err
+	}
+	return nil
+}

--- a/httpserver/handlers.go
+++ b/httpserver/handlers.go
@@ -1,0 +1,53 @@
+package httpserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	e "github.com/deislabs/hora/pkg/executor"
+	"github.com/sirupsen/logrus"
+)
+
+func (server *Server) verify(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+	logrus.Infof("start request %v %v", r.Method, r.URL)
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
+	subject := string(body)
+
+	logrus.Infof("subject for request %v %v is %v", r.Method, r.URL, subject)
+
+	verifyParameters := e.VerifyParameters{
+		Subject: subject,
+	}
+
+	result, err := server.Executor.VerifySubject(ctx, verifyParameters)
+
+	if err != nil {
+		return err
+	}
+
+	logrus.Infof("request %v %v completed successfully", r.Method, r.URL)
+	res, err := json.MarshalIndent(result, "", "  ")
+	if err == nil {
+		fmt.Println(string(res))
+	}
+
+	if result.IsSuccess {
+		return serveJSON(w, "true")
+	} else {
+		return serveJSON(w, "false")
+	}
+}
+
+func serveJSON(w http.ResponseWriter, result string) error {
+	if err := json.NewEncoder(w).Encode(result); err != nil {
+		return err
+	}
+	return nil
+}

--- a/httpserver/server.go
+++ b/httpserver/server.go
@@ -1,0 +1,73 @@
+package httpserver
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+
+	ef "github.com/deislabs/hora/pkg/executor/core"
+	"github.com/gorilla/mux"
+)
+
+const (
+	ServerRootURL = "/hora/v1"
+)
+
+type (
+	Server struct {
+		Address  string
+		Router   *mux.Router
+		Executor *ef.Executor
+		Context  context.Context
+	}
+)
+
+func NewServer(context context.Context, address string, executor *ef.Executor) (*Server, error) {
+	if address == "" {
+		return nil, ServerAddrNotFoundError{}
+	}
+
+	server := &Server{
+		Address:  address,
+		Executor: executor,
+		Router:   mux.NewRouter(),
+		Context:  context,
+	}
+	server.registerHandlers()
+
+	return server, nil
+}
+
+func (server *Server) Run() error {
+	tcpAddr, err := net.ResolveTCPAddr("tcp", server.Address)
+	if err != nil {
+		return err
+	}
+	lsnr, err := net.ListenTCP("tcp", tcpAddr)
+	if err != nil {
+		return err
+	}
+	svr := http.Server{
+		Addr:    server.Address,
+		Handler: server.Router,
+	}
+	return svr.Serve(lsnr)
+}
+
+func (server *Server) register(method, path string, handler ContextHandler) {
+	server.Router.Methods(method).Path(path).Handler(&contextHandler{
+		context: server.Context,
+		handler: handler,
+	})
+}
+
+func (server *Server) registerHandlers() {
+	server.register("GET", ServerRootURL+"/verify", server.verify)
+}
+
+type ServerAddrNotFoundError struct{}
+
+func (err ServerAddrNotFoundError) Error() string {
+	return fmt.Sprint("The http server address configuration is not set. Skipping server creation")
+}

--- a/pkg/executor/core/errors.go
+++ b/pkg/executor/core/errors.go
@@ -4,7 +4,7 @@ import "errors"
 
 var (
 	ReferrerStoreNotFound = errors.New("Cannot find any referrer stores for the given subject")
-	ReferrersNotFound     = errors.New("Referrers not found")
+	ReferrersNotFound     = errors.New("no referrers found for this artifact")
 )
 
 type ReferenceParseError struct {

--- a/pkg/executor/core/executor.go
+++ b/pkg/executor/core/executor.go
@@ -40,6 +40,7 @@ func (executor Executor) verifySubjectInternal(ctx context.Context, verifyParame
 	}
 
 	var verifierReports []interface{}
+	allVerifySuccess := true
 
 	for _, referrerStore := range executor.ReferrerStores {
 		var continuationToken string
@@ -59,6 +60,7 @@ func (executor Executor) verifySubjectInternal(ctx context.Context, verifyParame
 					verifierReports = append(verifierReports, verifyResult.VerifierReports...)
 
 					if !verifyResult.IsSuccess {
+						allVerifySuccess = false
 						result := types.VerifyResult{IsSuccess: false, VerifierReports: verifierReports}
 						if !executor.PolicyEnforcer.ContinueVerifyOnFailure(ctx, subjectReference, reference, result) {
 							return result, nil
@@ -78,7 +80,7 @@ func (executor Executor) verifySubjectInternal(ctx context.Context, verifyParame
 		return types.VerifyResult{}, ReferrersNotFound
 	}
 
-	return types.VerifyResult{IsSuccess: true, VerifierReports: verifierReports}, nil
+	return types.VerifyResult{IsSuccess: allVerifySuccess, VerifierReports: verifierReports}, nil
 }
 
 func (ex Executor) verifyReference(ctx context.Context, subjectRef common.Reference, referenceDesc ocispecs.ReferenceDescriptor, referrerStore referrerstore.ReferrerStore) types.VerifyResult {

--- a/pkg/policyprovider/configpolicy/configpolicy.go
+++ b/pkg/policyprovider/configpolicy/configpolicy.go
@@ -23,8 +23,9 @@ func (enforcer PolicyEnforcer) ContinueVerifyOnFailure(ctx context.Context, subj
 
 func (enforcer PolicyEnforcer) ErrorToVerifyResult(ctx context.Context, subjectRefString string, verifyError error) types.VerifyResult {
 	errorReport := verifier.VerifierResult{
+		Subject:   subjectRefString,
 		IsSuccess: false,
-		Results:   []string{fmt.Sprintf("error in the verification process %v", verifyError)},
+		Results:   []string{fmt.Sprintf("verification failed: %v", verifyError)},
 	}
 
 	// TODO  Look for better writing this code segment.

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -2,33 +2,13 @@ package utils
 
 import (
 	"fmt"
-	"strings"
 
 	_ "crypto/sha256"
 
 	"github.com/deislabs/hora/pkg/common"
+	"github.com/docker/distribution/reference"
 	"github.com/opencontainers/go-digest"
 )
-
-func ParseSubjectReference(subRef string) (common.Reference, error) {
-	referenceParts := strings.Split(subRef, "@")
-
-	if len(referenceParts) != 2 {
-		return common.Reference{}, fmt.Errorf("Subject reference %s should be a reference with Digest", subRef)
-	}
-
-	digest, err := digest.Parse(referenceParts[1])
-	if err != nil {
-		return common.Reference{}, fmt.Errorf("The digest of the subject is invalid %s %v", referenceParts[1], err)
-	}
-
-	// TODO switch to using distribution Reference object with Named and Path
-	return common.Reference{
-		Path:     referenceParts[0],
-		Digest:   digest,
-		Original: subRef,
-	}, nil
-}
 
 func ParseDigest(digestStr string) (digest.Digest, error) {
 
@@ -40,7 +20,7 @@ func ParseDigest(digestStr string) (digest.Digest, error) {
 	return digest, nil
 }
 
-/*func ParseSubjectReference(subRef string) (common.Reference, error) {
+func ParseSubjectReference(subRef string) (common.Reference, error) {
 	parseResult, err := reference.Parse(subRef)
 	if err != nil {
 		return common.Reference{}, fmt.Errorf("failed to parse subject reference %v", err)
@@ -49,7 +29,7 @@ func ParseDigest(digestStr string) (digest.Digest, error) {
 	var subjectRef common.Reference
 
 	if named, ok := parseResult.(reference.Named); ok {
-		subjectRef.Path = named
+		subjectRef.Path = named.Name()
 	} else {
 		return common.Reference{}, fmt.Errorf("failed to parse subject reference Path")
 	}
@@ -60,5 +40,11 @@ func ParseDigest(digestStr string) (digest.Digest, error) {
 		return common.Reference{}, fmt.Errorf("failed to parse subject reference digest")
 	}
 
+	if tag, ok := parseResult.(reference.Tagged); ok {
+		subjectRef.Tag = tag.Tag()
+	}
+
+	subjectRef.Original = subRef
+
 	return subjectRef, nil
-}*/
+}

--- a/pkg/verifier/api.go
+++ b/pkg/verifier/api.go
@@ -10,11 +10,11 @@ import (
 )
 
 type VerifierResult struct {
-	Subject       string
-	IsSuccess     bool
-	Name          string
-	Results       []string
-	NestedResults []VerifierResult
+	Subject       string           `json:"subject,omitempty"`
+	IsSuccess     bool             `json:"isSuccess,omitempty"`
+	Name          string           `json:"name,omitempty"`
+	Results       []string         `json:"results,omitempty"`
+	NestedResults []VerifierResult `json:"nestedResults,omitempty"`
 }
 
 type ReferenceVerifier interface {

--- a/plugins/referrerstore/sample/sample.go
+++ b/plugins/referrerstore/sample/sample.go
@@ -6,7 +6,6 @@ import (
 	"github.com/deislabs/hora/pkg/referrerstore"
 	"github.com/deislabs/hora/pkg/referrerstore/plugin/skel"
 	"github.com/opencontainers/go-digest"
-	oci "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 func main() {
@@ -31,5 +30,5 @@ func GetBlobContent(args *skel.CmdArgs, subjectReference common.Reference, diges
 }
 
 func GetReferenceManifest(args *skel.CmdArgs, subjectReference common.Reference, digest digest.Digest) (ocispecs.ReferenceManifest, error) {
-	return ocispecs.ReferenceManifest{SubjectDecriptor: oci.Descriptor{MediaType: "testMediaType"}}, nil
+	return ocispecs.ReferenceManifest{MediaType: "testMediaType", ArtifactType: "testArtifactType"}, nil
 }

--- a/plugins/verifier/nv2verifier/nv2verifier.go
+++ b/plugins/verifier/nv2verifier/nv2verifier.go
@@ -83,7 +83,7 @@ func VerifyReference(args *skel.CmdArgs, subjectReference common.Reference, refe
 				Subject:   subjectReference.String(),
 				Name:      input.Name,
 				IsSuccess: false,
-				Results:   []string{fmt.Sprintf("%v", err)},
+				Results:   []string{fmt.Sprintf("signature verification failed: %v", err)},
 			}, nil
 		}
 	}
@@ -91,7 +91,7 @@ func VerifyReference(args *skel.CmdArgs, subjectReference common.Reference, refe
 	return &verifier.VerifierResult{
 		Name:      input.Name,
 		IsSuccess: true,
-		Results:   []string{"Notary verification success"},
+		Results:   []string{"signature verification success"},
 	}, nil
 }
 


### PR DESCRIPTION
This PR has all the deployment, gatekeeper template files to enable the use Hora in Kubernetes admission controller using OPA Gatekeeper. A serve option is added to Hora to allow for running as Http server. This server will be used as the external data provider within Gatekeeper to fetch the verification status of image . This status will be used to apply the OPA policy on the deployment object whether to allow or deny. A brief document is also added to guide the setup of Hora in Kubernetes. 