### PR TITLE
Added version command

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -14,8 +14,8 @@ jobs:
       - name: setup go environment
         uses: actions/setup-go@v1
         with:
-          go-version: '1.16'
+          go-version: "1.16"
       - name: Build CLI
         run: make
       - name: Check build
-        run: bin/ratify --help
+        run: bin/ratify version

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,16 @@
-BINARY_NAME=ratify
-INSTALL_DIR=~/.ratify
+BINARY_NAME		= ratify
+INSTALL_DIR		= ~/.ratify
+
+GO_PKG			= github.com/deislabs/ratify
+GIT_COMMIT_HASH = $(shell git rev-parse HEAD)
+GIT_TREE_STATE 	= $(shell test -n "`git status --porcelain`" && echo "modified" || echo "unmodified")
+GIT_TAG     	= $(shell git describe --tags --abbrev=0 --exact-match 2>/dev/null)
+
+LDFLAGS = -w
+LDFLAGS += -X $(GO_PKG)/internal/version.GitCommitHash=$(GIT_COMMIT_HASH)
+LDFLAGS += -X $(GO_PKG)/internal/version.GitTreeState=$(GIT_TREE_STATE)
+LDFLAGS += -X $(GO_PKG)/internal/version.GitTag=$(GIT_TAG)
+
 all: build test
 
 .PHONY: build
@@ -7,7 +18,8 @@ build: build-cli build-plugins
 
 .PHONY: build-cli 
 build-cli:
-	go build -o ./bin/${BINARY_NAME} ./cmd/${BINARY_NAME}
+	go build --ldflags="$(LDFLAGS)" \
+	-o ./bin/${BINARY_NAME} ./cmd/${BINARY_NAME}
 
 .PHONY: build-plugins
 build-plugins: 

--- a/cmd/ratify/cmd/root.go
+++ b/cmd/ratify/cmd/root.go
@@ -39,6 +39,7 @@ func New(use, short string) *cobra.Command {
 	root.AddCommand(NewCmdVerify(use, verifyUse))
 	root.AddCommand(NewCmdServe(use, serveUse))
 	root.AddCommand(NewCmdDiscover(use, discoverUse))
+	root.AddCommand(NewCmdVersion(use, versionUse))
 
 	// TODO debug logging
 	return root

--- a/cmd/ratify/cmd/version.go
+++ b/cmd/ratify/cmd/version.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+
+	"github.com/deislabs/ratify/internal/version"
+	"github.com/spf13/cobra"
+)
+
+const (
+	versionUse = "version"
+)
+
+func NewCmdVersion(argv ...string) *cobra.Command {
+
+	eg := `  Example - print version:
+ratify version`
+
+	cmd := &cobra.Command{
+		Use:     versionUse,
+		Short:   "Show the ratify version information",
+		Example: eg,
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runVersion()
+		},
+	}
+
+	return cmd
+}
+
+func runVersion() error {
+	items := [][]string{
+		{"Go version", runtime.Version()},
+	}
+
+	// Tag is inserted as the version
+	if len(version.GitTag) > 0 {
+		items = append([][]string{{"Version", version.GitTag}}, items...)
+	}
+
+	if len(version.GitCommitHash) > 0 {
+		items = append(items, []string{"Git commit", version.GitCommitHash})
+	}
+
+	if len(version.GitTreeState) > 0 &&
+		version.GitTreeState != "unmodified" {
+		items = append(items, []string{"Git tree", version.GitTreeState})
+	}
+
+	// Get max string lenght of first column
+	var size = 0
+	for _, item := range items {
+		if size < len(item[0]) {
+			size = len(item[0])
+		}
+	}
+
+	for _, item := range items {
+		fmt.Println(item[0] + ": " + strings.Repeat(" ", size-len(item[0])) + item[1])
+	}
+
+	return nil
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+var (
+
+	//GitTag
+	GitTag = ""
+
+	//GitCommitHash is the full commit hash.
+	GitCommitHash = ""
+
+	//GitTreeState shows if the tree is unmodified or modified
+	GitTreeState = ""
+)


### PR DESCRIPTION
Signed-off-by: Sajay Antony <sajaya@microsoft.com>

Supports a version command. 

Go releaser also needs to get updated to pass in these `LDFLAGS` 

```
➜ ./bin/ratify version
Version:    test1
Go version: go1.16.7
Git commit: 99bbb2c65cea5c2aead1e3755cd9bab938990045
Git tree:   modified
```
