### PR TITLE
Add quick start tutorial with latest steps for creating supply chain graph

### DIFF
--- a/cmd/ratify/cmd/discover.go
+++ b/cmd/ratify/cmd/discover.go
@@ -16,13 +16,16 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/deislabs/ratify/config"
+	"github.com/deislabs/ratify/pkg/common"
 	"github.com/deislabs/ratify/pkg/ocispecs"
+	"github.com/deislabs/ratify/pkg/referrerstore"
 	sf "github.com/deislabs/ratify/pkg/referrerstore/factory"
 	"github.com/deislabs/ratify/pkg/utils"
 	"github.com/spf13/cobra"
@@ -72,6 +75,18 @@ func NewCmdDiscover(argv ...string) *cobra.Command {
 	return cmd
 }
 
+type listResult struct {
+	Name       string                         `json:"storeName"`
+	References []ocispecs.ReferenceDescriptor `json:"References,omitempty"`
+}
+
+func Test(subject string) {
+	listReferrers((referrerCmdOptions{
+		subject:       subject,
+		artifactTypes: []string{"myartifact"},
+	}))
+}
+
 func discover(opts discoverCmdOptions) error {
 
 	if opts.subject == "" {
@@ -119,4 +134,90 @@ func discover(opts discoverCmdOptions) error {
 	}
 
 	return PrintJSON(results)
+}
+
+func listReferrers(opts referrerCmdOptions) error {
+
+	if opts.subject == "" {
+		return errors.New("subject parameter is required")
+	}
+
+	subRef, err := utils.ParseSubjectReference(opts.subject)
+	if err != nil {
+		return err
+	}
+
+	cf, err := config.Load(opts.configFilePath)
+	if err != nil {
+		return err
+	}
+
+	// TODO replace with code
+	rootImage := treeprint.NewWithRoot(subRef.String())
+
+	stores, err := sf.CreateStoresFromConfig(cf.StoresConfig, config.GetDefaultPluginPath())
+
+	if err != nil {
+		return err
+	}
+
+	type Result struct {
+		Name       string
+		References []ocispecs.ReferenceDescriptor
+	}
+
+	var results []listResult
+
+	for _, referrerStore := range stores {
+		storeNode := rootImage.AddBranch(referrerStore.Name())
+		result, err := listReferrersForStore(subRef, opts.artifactTypes, referrerStore, storeNode)
+		if err != nil {
+			return err
+		}
+		results = append(results, *result)
+	}
+
+	if !opts.flatOutput {
+		fmt.Println(rootImage.String())
+		return nil
+	}
+
+	return PrintJSON(results)
+}
+
+func listReferrersForStore(subRef common.Reference, artifactTypes []string, store referrerstore.ReferrerStore, treeNode treeprint.Tree) (*listResult, error) {
+	var continuationToken string
+	result := listResult{
+		Name: store.Name(),
+	}
+
+	for {
+		lr, err := store.ListReferrers(context.Background(), subRef, artifactTypes, continuationToken)
+		if err != nil {
+			return nil, err
+		}
+
+		continuationToken = lr.NextToken
+		for _, ref := range lr.Referrers {
+			refNode := treeNode.AddBranch(fmt.Sprintf("[%s]%s", ref.ArtifactType, ref.Digest.String()))
+			sr := common.Reference{
+				Path:     subRef.Path,
+				Digest:   ref.Digest,
+				Original: fmt.Sprintf("%s@%s", subRef.Path, ref.Digest),
+			}
+
+			subResult, err := listReferrersForStore(sr, artifactTypes, store, refNode)
+			if err != nil {
+				return nil, err
+			}
+			result.References = append(result.References, subResult.References...)
+
+		}
+		result.References = append(result.References, lr.Referrers...)
+		if continuationToken == "" {
+			break
+		}
+	}
+
+	return &result, nil
 }

--- a/plugins/verifier/sbom/sbom.go
+++ b/plugins/verifier/sbom/sbom.go
@@ -19,11 +19,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/deislabs/ratify/pkg/common"
 	"github.com/deislabs/ratify/pkg/ocispecs"
 	"github.com/deislabs/ratify/pkg/referrerstore"
+
 	// This import is required to utilize the oras built-in referrer store
 	_ "github.com/deislabs/ratify/pkg/referrerstore/oras"
 	"github.com/deislabs/ratify/pkg/verifier"
@@ -31,8 +31,7 @@ import (
 )
 
 type PluginConfig struct {
-	Name             string `json:"name"`
-	AlpineMinVersion string `json:"alpineMinVersion"`
+	Name string `json:"name"`
 }
 
 type PluginInputConfig struct {
@@ -45,8 +44,7 @@ type PackageInfo struct {
 }
 
 type SbomContents struct {
-	Contents string        `json:"contents"`
-	Packages []PackageInfo `json:"packages,omitempty"`
+	Contents string `json:"contents"`
 }
 
 func main() {
@@ -87,21 +85,19 @@ func VerifyReference(args *skel.CmdArgs, subjectReference common.Reference, refe
 			return nil, fmt.Errorf("failed to parse sbom: %v", err)
 		}
 
-		for _, p := range sbomBlob.Packages {
-			if strings.HasPrefix(p.Name, "alpine-base") && p.Version < input.AlpineMinVersion {
-				return &verifier.VerifierResult{
-					Name:      input.Name,
-					IsSuccess: false,
-					Results:   []string{fmt.Sprintf("SBOM verification failed. The artifact has base image 'alpine' with version below '%s' and not compliant.", input.AlpineMinVersion)},
-				}, nil
-			}
+		if sbomBlob.Contents == "bad" {
+			return &verifier.VerifierResult{
+				Name:      input.Name,
+				IsSuccess: false,
+				Results:   []string{fmt.Sprintf("SBOM verification failed. The contents is %s.", sbomBlob.Contents)},
+			}, nil
 		}
 	}
 
 	return &verifier.VerifierResult{
 		Name:      input.Name,
 		IsSuccess: true,
-		Results:   []string{"SBOM verification success."},
+		Results:   []string{"SBOM verification success. The contents is good."},
 	}, nil
 
 }


### PR DESCRIPTION
- Updated README with quick start tutorial for creating the graph and verifying it using ratify
- Changed SBoM verifier to work with simulated SBoM created in the tutorial
- Removed ```ratify referrer list``` as it is replaced by ```ratify discover```

Signed-off-by: Tejaswini Duggaraju <naduggar@microsoft.com>