### PR TITLE
Support private registry in oras

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,5 +17,5 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.2.1
 	github.com/xlab/treeprint v1.1.0
-	oras.land/oras-go v0.5.1-0.20211118233813-9ec21342ac6c
+	oras.land/oras-go v0.5.1-0.20211129233629-3b1e924da9d7
 )

--- a/go.sum
+++ b/go.sum
@@ -2530,8 +2530,8 @@ mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jC
 mvdan.cc/unparam v0.0.0-20210104141923-aac4ce9116a7/go.mod h1:hBpJkZE8H/sb+VRFvw2+rBpHNsTBcvSpk61hr8mzXZE=
 nhooyr.io/websocket v1.8.6/go.mod h1:B70DZP8IakI65RVQ51MsWP/8jndNma26DVA/nFSCgW0=
 nhooyr.io/websocket v1.8.7/go.mod h1:B70DZP8IakI65RVQ51MsWP/8jndNma26DVA/nFSCgW0=
-oras.land/oras-go v0.5.1-0.20211118233813-9ec21342ac6c h1:ahEyjNEVBRqxTZglDwnUgapWmeHCZe4kDOQwN6epf6g=
-oras.land/oras-go v0.5.1-0.20211118233813-9ec21342ac6c/go.mod h1:s/Q8+g2H7MHrEImZfquIA+RpBdV7fb4CQDff10i/DQ4=
+oras.land/oras-go v0.5.1-0.20211129233629-3b1e924da9d7 h1:iCxH9uBANXN6z4OLwblnrOabOtcUnc3ylv5TpXhQ/ts=
+oras.land/oras-go v0.5.1-0.20211129233629-3b1e924da9d7/go.mod h1:s/Q8+g2H7MHrEImZfquIA+RpBdV7fb4CQDff10i/DQ4=
 pack.ag/amqp v0.11.2/go.mod h1:4/cbmt4EJXSKlG6LCfWHoqmN0uFdy5i/+YFz+fTfhV4=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=


### PR DESCRIPTION
- Import oras library that has fix for authenticating a private registry.
- Remove dependency on crane for resolving the descriptor for a subject as Resolve is available in oras library

Signed-off-by: Tejaswini Duggaraju <naduggar@microsoft.com>