### PR TITLE
Add support for authenticating registries with Docker config

### DIFF
--- a/charts/ratify/templates/deployment.yaml
+++ b/charts/ratify/templates/deployment.yaml
@@ -35,12 +35,28 @@ spec:
             - mountPath: "/usr/local/ratify"
               name: config
               readOnly: true
+          {{- if .Values.dockerConfig }}
+            - mountPath: "/usr/local/docker"
+              name: dockerconfig
+              readOnly: true
+          env:
+            - name: DOCKER_CONFIG
+              value: "/usr/local/docker"
+          {{ end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
         - name: certs
           secret:
             secretName: {{ include "ratify.fullname" . }}-certificate
+        {{- if .Values.dockerConfig }}
+        - name: dockerconfig
+          secret:
+            secretName: {{ include "ratify.fullname" . }}-dockerconfig
+            items:
+              - key: .dockerconfigjson
+                path: config.json
+        {{ end }}
         - name: config
           configMap:
             name: {{ include "ratify.fullname" . }}-configuration

--- a/charts/ratify/templates/dockerconfigsecret.yaml
+++ b/charts/ratify/templates/dockerconfigsecret.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.dockerConfig }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ratify.fullname" . }}-dockerconfig
+data:
+  .dockerconfigjson: {{ .Values.dockerConfig | b64enc | quote }}
+type: kubernetes.io/dockerconfigjson
+{{ end }}

--- a/cmd/ratify/cmd/discover.go
+++ b/cmd/ratify/cmd/discover.go
@@ -82,9 +82,9 @@ type listResult struct {
 }
 
 func Test(subject string) {
-	listReferrers((referrerCmdOptions{
+	discover((discoverCmdOptions{
 		subject:       subject,
-		artifactTypes: []string{"myartifact"},
+		artifactTypes: []string{""},
 	}))
 }
 


### PR DESCRIPTION
- Added support for authenticating registries using Docker config
-  The helm install/upgrade command would be 

```bash
helm install ratify charts/ratify --set-file dockerConfig=<path to the local Docker config.json file>
```
- This will create a [Docker config](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#registry-secret-existing-credentials) k8s secret, mount the file to the ratify container and set the DOCKER_CONFIG
- If the env DOCKER_CONFIG is set, oras store will use it to authenticate the private registry if its credentials are configured in the docker config file.


Signed-off-by: Tejaswini Duggaraju <naduggar@microsoft.com>