### PR TITLE
Updates to deployment helm chart to support Certificate from Azure Key vault

### DIFF
--- a/charts/ratify/templates/_helpers.tpl
+++ b/charts/ratify/templates/_helpers.tpl
@@ -6,6 +6,13 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
+Define secret provider class name.
+*/}}
+{{- define "ratify.akv.secretProviderClassName" -}}
+{{ include "ratify.fullname" . }}-akv-secret-provider
+{{- end }}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.

--- a/charts/ratify/templates/akv-secret-provider.yaml
+++ b/charts/ratify/templates/akv-secret-provider.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.akvCertConfig.enabled }}
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: {{ include "ratify.fullname" . }}-akv-secret-provider
+spec:
+  provider: azure
+  parameters:
+    usePodIdentity: "true"
+    keyvaultName: {{ required "vaultName must be provided when AKV cert config is enabled" .Values.akvCertConfig.vaultName  }}       # Set to the name of your key vault
+    objects:  |
+      array:
+        - |
+          objectName: {{ required "certName must be provided when AKV cert config is enabled" .Values.akvCertConfig.certName  }} 
+          objectType: cert
+          objectAlias: ratify-test.crt
+
+    tenantId: {{ required "tenantId must be provided when AKV cert config is enabled" .Values.akvCertConfig.tenantId  }}
+{{ end }}

--- a/charts/ratify/templates/akv-secret-provider.yaml
+++ b/charts/ratify/templates/akv-secret-provider.yaml
@@ -2,18 +2,17 @@
 apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
-  name: {{ include "ratify.fullname" . }}-akv-secret-provider
+  name: {{ include "ratify.akv.secretProviderClassName" . }}
 spec:
   provider: azure
   parameters:
     usePodIdentity: "true"
-    keyvaultName: {{ required "vaultName must be provided when AKV cert config is enabled" .Values.akvCertConfig.vaultName  }}       # Set to the name of your key vault
+    keyvaultName: {{ required "vaultName must be provided when AKV cert config is enabled" .Values.akvCertConfig.vaultName  }}
     objects:  |
       array:
         - |
-          objectName: {{ required "certName must be provided when AKV cert config is enabled" .Values.akvCertConfig.certName  }} 
+          objectName: {{ required "certName must be provided when AKV cert config is enabled" .Values.akvCertConfig.certName  }}
           objectType: cert
           objectAlias: ratify-test.crt
-
     tenantId: {{ required "tenantId must be provided when AKV cert config is enabled" .Values.akvCertConfig.tenantId  }}
-{{ end }}
+{{- end }}

--- a/charts/ratify/templates/akv-secret-provider.yaml
+++ b/charts/ratify/templates/akv-secret-provider.yaml
@@ -15,4 +15,4 @@ spec:
           objectType: cert
           objectAlias: ratify-test.crt
     tenantId: {{ required "tenantId must be provided when AKV cert config is enabled" .Values.akvCertConfig.tenantId  }}
-{{- end }}
+{{ end }}

--- a/charts/ratify/templates/deployment.yaml
+++ b/charts/ratify/templates/deployment.yaml
@@ -14,6 +14,9 @@ spec:
     metadata:
       labels:
         {{- include "ratify.selectorLabels" . | nindent 8 }}
+        {{- if .Values.akvCertConfig.enabled }}
+        aadpodidbinding: {{ required "aadPodIdentity must be provided when AKV cert config is enabled" .Values.akvCertConfig.aadPodIdentity  }}
+        {{ end }}
     spec:
       containers:
         - name: {{ .Chart.Name }}
@@ -31,7 +34,11 @@ spec:
             - containerPort: 6001
           volumeMounts:
             - mountPath: "/usr/local/ratify-certs"
+              {{- if .Values.akvCertConfig.enabled }}
+              name: cert-from-akv
+              {{ else }}
               name: certs
+              {{ end }}
               readOnly: true
             - mountPath: "/usr/local/ratify"
               name: config
@@ -61,6 +68,14 @@ spec:
             items:
               - key: .dockerconfigjson
                 path: config.json
+        {{ end }}
+        {{- if .Values.akvCertConfig.enabled }}
+        - name: cert-from-akv
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: "{{ include "ratify.fullname" . }}-akv-secret-provider"
         {{ end }}
         - name: config
           configMap:

--- a/charts/ratify/templates/deployment.yaml
+++ b/charts/ratify/templates/deployment.yaml
@@ -16,7 +16,7 @@ spec:
         {{- include "ratify.selectorLabels" . | nindent 8 }}
         {{- if .Values.akvCertConfig.enabled }}
         aadpodidbinding: {{ required "aadPodIdentity must be provided when AKV cert config is enabled" .Values.akvCertConfig.aadPodIdentity  }}
-        {{ end }}
+        {{- end }}
     spec:
       containers:
         - name: {{ .Chart.Name }}
@@ -36,9 +36,9 @@ spec:
             - mountPath: "/usr/local/ratify-certs"
               {{- if .Values.akvCertConfig.enabled }}
               name: cert-from-akv
-              {{ else }}
+              {{- else }}
               name: certs
-              {{ end }}
+              {{- end }}
               readOnly: true
             - mountPath: "/usr/local/ratify"
               name: config
@@ -50,7 +50,7 @@ spec:
           env:
             - name: DOCKER_CONFIG
               value: "/usr/local/docker"
-          {{ end }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
@@ -62,21 +62,21 @@ spec:
           secret:
             {{- if .Values.registryCredsSecret }}
             secretName: {{ .Values.registryCredsSecret }}
-            {{ else }}
+            {{- else }}
             secretName: {{ include "ratify.fullname" . }}-dockerconfig
-            {{ end }}
+            {{- end }}
             items:
               - key: .dockerconfigjson
                 path: config.json
-        {{ end }}
+        {{- end }}
         {{- if .Values.akvCertConfig.enabled }}
         - name: cert-from-akv
           csi:
             driver: secrets-store.csi.k8s.io
             readOnly: true
             volumeAttributes:
-              secretProviderClass: "{{ include "ratify.fullname" . }}-akv-secret-provider"
-        {{ end }}
+              secretProviderClass: "{{ include "ratify.akv.secretProviderClassName" . }}"
+        {{- end }}
         - name: config
           configMap:
             name: {{ include "ratify.fullname" . }}-configuration

--- a/charts/ratify/templates/dockerconfigsecret.yaml
+++ b/charts/ratify/templates/dockerconfigsecret.yaml
@@ -6,4 +6,4 @@ metadata:
 data:
   .dockerconfigjson: {{ .Values.dockerConfig | b64enc | quote }}
 type: kubernetes.io/dockerconfigjson
-{{ end }}
+{{- end }}

--- a/charts/ratify/templates/dockerconfigsecret.yaml
+++ b/charts/ratify/templates/dockerconfigsecret.yaml
@@ -6,4 +6,4 @@ metadata:
 data:
   .dockerconfigjson: {{ .Values.dockerConfig | b64enc | quote }}
 type: kubernetes.io/dockerconfigjson
-{{- end }}
+{{ end }}

--- a/charts/ratify/values.yaml
+++ b/charts/ratify/values.yaml
@@ -31,3 +31,9 @@ resources:
    requests:
      cpu: 100m
      memory: 128Mi
+akvCertConfig:
+  enabled: false
+  vaultName:
+  certName:
+  tenantId:
+  aadPodIdentity:


### PR DESCRIPTION
- Added support of Azure keyvault provider to secret store CSI driver in AKS. With this support, the notation certificate can be obtained from AKV certificate that gets mounted to the ```ratify``` container
- The AKV is accessed using the AAD pod identity in AKS. The necessary steps to setup all the required add-ons and the configuration to enable this access in the ratify is outlined in the [Hack doc](https://hackmd.io/OPhToZZaQ3K36hyy9jTy7g?both)
-  Addresses #76 where notation CLI can be used to perform remote signing and ```ratify``` can be used to perform local verification using ```notation``` libraries. 