### PR TITLE
Fix for cosign verifier

### DIFF
--- a/pkg/referrerstore/oras/cosign.go
+++ b/pkg/referrerstore/oras/cosign.go
@@ -26,16 +26,12 @@ import (
 	oci "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sigstore/cosign/pkg/cosign"
 	"net/http"
-	"strings"
 )
 
 const CosignArtifactType = "org.sigstore.cosign.v1"
 
 func getCosignReferences(subjectReference common.Reference) (*[]ocispecs.ReferenceDescriptor, error) {
 	var references []ocispecs.ReferenceDescriptor
-	if strings.Split(subjectReference.Original, "@")[1] == "" {
-		return &references, nil
-	}
 	ref, err := name.ParseReference(subjectReference.Original)
 	if err != nil {
 		return &references, err


### PR DESCRIPTION
This change fixes an issue with cosign manifest discovery and allows the oras referrerstore to be used for registries that only support cosign artifacts.

With the tag to digest implementation the subjectReference is now passed in with proper values to use directly with the cosign APIs and does not require this string check anymore.

When oras `Discover` is called it returns a 404 if the registry does not support oras endpoints. We check for the 404 and if cosign is enabled there is still a chance that cosign artifacts could be discovered in a later call. We log a message and allow the function to continue.

This change was tested against:
- Local registry with oras support and no artifacts
- Local registry with oras support and only cosign signatures
- Local registry with oras support, notaryv2 signatures, and cosign signatures
- ECR public registry without oras support and only cosign signatures