### PR TITLE
[Bugfix] Updating default timeout

### DIFF
--- a/httpserver/handlers.go
+++ b/httpserver/handlers.go
@@ -78,10 +78,10 @@ func (server *Server) verify(ctx context.Context, w http.ResponseWriter, r *http
 			})
 		}
 	}
-	return sendResponse(&results, "", w)
+	return sendResponse(&results, "", w, http.StatusOK)
 }
 
-func sendResponse(results *[]externaldata.Item, systemErr string, w http.ResponseWriter) error {
+func sendResponse(results *[]externaldata.Item, systemErr string, w http.ResponseWriter, respCode int) error {
 	response := externaldata.ProviderResponse{
 		APIVersion: apiVersion,
 		Kind:       "ProviderResponse",
@@ -93,7 +93,7 @@ func sendResponse(results *[]externaldata.Item, systemErr string, w http.Respons
 		response.Response.SystemError = systemErr
 	}
 
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(respCode)
 	return json.NewEncoder(w).Encode(response)
 }
 
@@ -118,7 +118,7 @@ func processTimeout(h ContextHandler, duration time.Duration) ContextHandler {
 		}
 
 		if err != nil {
-			return sendResponse(nil, fmt.Sprintf("validate operation failed with error %v", err), w)
+			return sendResponse(nil, fmt.Sprintf("validate operation failed with error %v", err), w, http.StatusInternalServerError)
 		}
 
 		return nil

--- a/httpserver/server_test.go
+++ b/httpserver/server_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package httpserver
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/deislabs/ratify/pkg/executor/core"
+	"github.com/deislabs/ratify/pkg/ocispecs"
+	config "github.com/deislabs/ratify/pkg/policyprovider/configpolicy"
+	"github.com/deislabs/ratify/pkg/referrerstore"
+	"github.com/deislabs/ratify/pkg/referrerstore/mocks"
+	"github.com/deislabs/ratify/pkg/verifier"
+	"github.com/open-policy-agent/frameworks/constraint/pkg/externaldata"
+	"github.com/opencontainers/go-digest"
+)
+
+func TestServer_Timeout_Failed(t *testing.T) {
+	timeoutDuration := 6
+	testImageName := "localhost:5000/net-monitor:v1"
+	t.Run("server_timeout_fail", func(t *testing.T) {
+		body := new(bytes.Buffer)
+		json.NewEncoder(body).Encode(externaldata.NewProviderRequest([]string{testImageName}))
+		request := httptest.NewRequest(http.MethodPost, "/ratify/gatekeeper/v1/verify", bytes.NewReader(body.Bytes()))
+		responseRecorder := httptest.NewRecorder()
+
+		testDigest := digest.FromString("test")
+		configPolicy := config.PolicyEnforcer{}
+		store := &mocks.TestStore{References: []ocispecs.ReferenceDescriptor{
+			{
+				ArtifactType: "test-type1",
+			}},
+			ResolveMap: map[string]digest.Digest{
+				"v1": testDigest,
+			},
+		}
+		ver := &core.TestVerifier{
+			CanVerifyFunc: func(at string) bool {
+				return at == "test-type1"
+			},
+			VerifyResult: func(artifactType string) bool {
+				time.Sleep(time.Duration(timeoutDuration) * time.Second)
+				return true
+			},
+		}
+
+		ex := &core.Executor{
+			PolicyEnforcer: configPolicy,
+			ReferrerStores: []referrerstore.ReferrerStore{store},
+			Verifiers:      []verifier.ReferenceVerifier{ver},
+		}
+		server := &Server{
+			Executor: ex,
+			Context:  request.Context(),
+		}
+
+		handler := contextHandler{
+			context: server.Context,
+			handler: processTimeout(server.verify, server.Executor.GetVerifyRequestTimeout()),
+		}
+
+		handler.ServeHTTP(responseRecorder, request)
+		if responseRecorder.Code != http.StatusInternalServerError {
+			t.Errorf("Want status '%d', got '%d'", http.StatusInternalServerError, responseRecorder.Code)
+		}
+	})
+}

--- a/pkg/executor/core/executor.go
+++ b/pkg/executor/core/executor.go
@@ -33,7 +33,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const defaultRequestTimeoutSeconds = 8
+const defaultRequestTimeoutSeconds = 3
 
 // Executor describes an execution engine that queries the stores for the supply chain content,
 // runs them through the verifiers as governed by the policy enforcer

--- a/pkg/executor/core/executor.go
+++ b/pkg/executor/core/executor.go
@@ -33,7 +33,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const defaultRequestTimeoutSeconds = 3
+const defaultRequestTimeoutMilliseconds = 2800
 
 // Executor describes an execution engine that queries the stores for the supply chain content,
 // runs them through the verifiers as governed by the policy enforcer
@@ -58,11 +58,11 @@ func (executor Executor) VerifySubject(ctx context.Context, verifyParameters e.V
 }
 
 func (executor Executor) GetVerifyRequestTimeout() time.Duration {
-	timeoutSeconds := defaultRequestTimeoutSeconds
+	timeoutMilliSeconds := defaultRequestTimeoutMilliseconds
 	if executor.Config != nil && executor.Config.RequestTimeout != nil {
-		timeoutSeconds = *executor.Config.RequestTimeout
+		timeoutMilliSeconds = *executor.Config.RequestTimeout
 	}
-	return time.Duration(timeoutSeconds) * time.Second
+	return time.Duration(timeoutMilliSeconds) * time.Millisecond
 }
 
 func (executor Executor) verifySubjectInternal(ctx context.Context, verifyParameters e.VerifyParameters) (types.VerifyResult, error) {

--- a/pkg/executor/core/executor_test.go
+++ b/pkg/executor/core/executor_test.go
@@ -105,10 +105,10 @@ func TestVerifySubject_CanVerify_ExpectedResults(t *testing.T) {
 		},
 	}
 	ver := &TestVerifier{
-		canVerify: func(at string) bool {
+		CanVerifyFunc: func(at string) bool {
 			return at == "test-type1"
 		},
-		verifyResult: func(artifactType string) bool {
+		VerifyResult: func(artifactType string) bool {
 			return true
 		},
 	}
@@ -153,10 +153,10 @@ func TestVerifySubject_VerifyFailures_ExpectedResults(t *testing.T) {
 		},
 	}
 	ver := &TestVerifier{
-		canVerify: func(at string) bool {
+		CanVerifyFunc: func(at string) bool {
 			return true
 		},
-		verifyResult: func(artifactType string) bool {
+		VerifyResult: func(artifactType string) bool {
 			if artifactType == "test-type1" {
 				return false
 			}
@@ -205,10 +205,10 @@ func TestVerifySubject_VerifySuccess_ExpectedResults(t *testing.T) {
 		},
 	}
 	ver := &TestVerifier{
-		canVerify: func(at string) bool {
+		CanVerifyFunc: func(at string) bool {
 			return true
 		},
-		verifyResult: func(artifactType string) bool {
+		VerifyResult: func(artifactType string) bool {
 			return true
 		},
 	}

--- a/pkg/executor/core/testtypes.go
+++ b/pkg/executor/core/testtypes.go
@@ -26,8 +26,8 @@ import (
 )
 
 type TestVerifier struct {
-	canVerify    func(artifactType string) bool
-	verifyResult func(artifactType string) bool
+	CanVerifyFunc func(artifactType string) bool
+	VerifyResult  func(artifactType string) bool
 }
 
 func (s *TestVerifier) Name() string {
@@ -35,7 +35,7 @@ func (s *TestVerifier) Name() string {
 }
 
 func (s *TestVerifier) CanVerify(ctx context.Context, referenceDescriptor ocispecs.ReferenceDescriptor) bool {
-	return s.canVerify(referenceDescriptor.ArtifactType)
+	return s.CanVerifyFunc(referenceDescriptor.ArtifactType)
 }
 
 func (s *TestVerifier) Verify(ctx context.Context,
@@ -44,6 +44,6 @@ func (s *TestVerifier) Verify(ctx context.Context,
 	referrerStore referrerstore.ReferrerStore,
 	executor executor.Executor) (verifier.VerifierResult, error) {
 	return verifier.VerifierResult{
-		IsSuccess: s.verifyResult(referenceDescriptor.ArtifactType),
+		IsSuccess: s.VerifyResult(referenceDescriptor.ArtifactType),
 	}, nil
 }


### PR DESCRIPTION
Fixes #92 

Root Cause:

- The Gatekeeper validating webhook timeout is set to 3 seconds while the current verification timeout is 8 seconds
- A longer running verification process will cause the Gatekeeper webhook to timeout and cancel the context
- The error will be emitted but code structure will short circuit to success. 

Solution: 
- Set timeout to be less than or equal to the webhook timeout (3 seconds). Verifier will timeout before webhook does and block the deployment as expected. 

Validation Steps:
1. Update notaryv2 plugin to sleep for time > 3 seconds
2. Attempt to deploy signed image. 
3. Deployment is blocked with error message: `Error from server ([ratify-constraint] Image verification failed : {"errors": [], "responses": [], "status_code": 200, "system_error": "validate operation failed with error operation timed out after duration 3s"}): admission webhook "validation.gatekeeper.sh" denied the request: [ratify-constraint] Image verification failed : {"errors": [], "responses": [], "status_code": 200, "system_error": "validate operation failed with error operation timed out after duration 3s"}`