### PR TITLE
Fix issue with oras local cache path

### DIFF
--- a/charts/ratify/templates/configmap.yaml
+++ b/charts/ratify/templates/configmap.yaml
@@ -9,11 +9,11 @@ data:
         "version": "1.0.0",
         "plugins": [
             {
-                "name": "oras",
+                "name": "oras"
                 {{- if .Values.cosign.enabled }}
-                "cosign-enabled": true,
+                ,
+                "cosign-enabled": true
                 {{- end }}
-                "localCachePath": "./local_oras_cache"
             }
         ]
       },

--- a/config/config.go
+++ b/config/config.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	ConfigFileName = "config.json"
-	configFileDir  = ".ratify"
+	ConfigFileDir  = ".ratify"
 	PluginsFolder  = "plugins"
 )
 
@@ -58,7 +58,7 @@ func InitDefaultPaths() {
 	}
 	configDir = os.Getenv("RATIFY_CONFIG")
 	if configDir == "" {
-		configDir = filepath.Join(getHomeDir(), configFileDir)
+		configDir = filepath.Join(getHomeDir(), ConfigFileDir)
 
 	}
 	defaultPluginsPath = filepath.Join(configDir, PluginsFolder)

--- a/config/config.json
+++ b/config/config.json
@@ -3,8 +3,7 @@
         "version": "1.0.0",
         "plugins": [
             {
-                "name": "oras",
-                "localCachePath": "./local_oras_cache"
+                "name": "oras"
             }
         ]
     },

--- a/pkg/referrerstore/oras/oras.go
+++ b/pkg/referrerstore/oras/oras.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	paths "path/filepath"
 	"strings"
 	"time"
 
@@ -94,7 +95,7 @@ func (s *orasStoreFactory) Create(version string, storeConfig config.StorePlugin
 
 	// Set up the local cache where content will land when we pull
 	if conf.LocalCachePath == "" {
-		conf.LocalCachePath = filepath.Join(homedir.Get(), ratifyconfig.ConfigFileDir, defaultLocalCachePath)
+		conf.LocalCachePath = paths.Join(homedir.Get(), ratifyconfig.ConfigFileDir, defaultLocalCachePath)
 	}
 	localRegistry, err := content.NewOCI(conf.LocalCachePath)
 	if err != nil {

--- a/pkg/referrerstore/oras/oras.go
+++ b/pkg/referrerstore/oras/oras.go
@@ -41,7 +41,7 @@ import (
 
 const (
 	storeName             = "oras"
-	defaultLocalCachePath = "~/.ratify/local_oras_cache"
+	defaultLocalCachePath = ".ratify/local_oras_cache"
 	dockerConfigFileName  = "config.json"
 )
 
@@ -92,11 +92,15 @@ func (s *orasStoreFactory) Create(version string, storeConfig config.StorePlugin
 
 	// Set up the local cache where content will land when we pull
 	if conf.LocalCachePath == "" {
-		conf.LocalCachePath = defaultLocalCachePath
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+		conf.LocalCachePath = filepath.Join(homeDir, defaultLocalCachePath)
 	}
 	localRegistry, err := content.NewOCI(conf.LocalCachePath)
 	if err != nil {
-		return nil, fmt.Errorf("could not create local oras cache at path #{conf.LocalCachePath}: #{err}")
+		return nil, fmt.Errorf("could not create local oras cache at path %s: %s", conf.LocalCachePath, err)
 	}
 
 	return &orasStore{config: &conf,

--- a/pkg/referrerstore/oras/oras.go
+++ b/pkg/referrerstore/oras/oras.go
@@ -27,7 +27,9 @@ import (
 	"oras.land/oras-go/pkg/oras"
 	"oras.land/oras-go/pkg/target"
 
+	ratifyconfig "github.com/deislabs/ratify/config"
 	"github.com/deislabs/ratify/pkg/common"
+	"github.com/deislabs/ratify/pkg/homedir"
 	"github.com/deislabs/ratify/pkg/ocispecs"
 	"github.com/deislabs/ratify/pkg/referrerstore"
 	"github.com/deislabs/ratify/pkg/referrerstore/config"
@@ -41,7 +43,7 @@ import (
 
 const (
 	storeName             = "oras"
-	defaultLocalCachePath = ".ratify/local_oras_cache"
+	defaultLocalCachePath = "local_oras_cache"
 	dockerConfigFileName  = "config.json"
 )
 
@@ -92,11 +94,7 @@ func (s *orasStoreFactory) Create(version string, storeConfig config.StorePlugin
 
 	// Set up the local cache where content will land when we pull
 	if conf.LocalCachePath == "" {
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			return nil, err
-		}
-		conf.LocalCachePath = filepath.Join(homeDir, defaultLocalCachePath)
+		conf.LocalCachePath = filepath.Join(homedir.Get(), ratifyconfig.ConfigFileDir, defaultLocalCachePath)
 	}
 	localRegistry, err := content.NewOCI(conf.LocalCachePath)
 	if err != nil {


### PR DESCRIPTION
This fixes an issue with creating the oras local cache directory in a distroless container image.

- Remove explicit `localCachePath` from the default `config.json`
- Update oras implementation to properly build the path for the `localCachePath`
- Fix an error message to properly display the path and error

Fixes #124