### PR TITLE
Add ORAS Authentication Provider Documentation 

### DIFF
--- a/docs/oras-auth-provider.md
+++ b/docs/oras-auth-provider.md
@@ -175,6 +175,8 @@ Ratify only supports the kubernetes.io/dockerconfigjson secret type or the legac
     }
 ```
 
+Note: Kubernetes secrets are reloaded and refreshed for Ratify to use every 12 hours. Changes to the Secret may not be reflected immediately. 
+
 ## Notational Conventions
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" are to be interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).

--- a/docs/oras-auth-provider.md
+++ b/docs/oras-auth-provider.md
@@ -2,7 +2,7 @@
 
 ORAS handles all referrer operations using registry as the referrer store. It uses authentication credentials to authenticate to a registry and access referrer artifacts. Ratify contains many Authentication Providers to support different authentication scenarios. The user specifies which authentication provider to use in the configuration.
 
-The `auth-provider` section of configuration file specifies the authentication provider. Ratify **requires** the `name` field to bind to the correct provider implementation. 
+The `auth-provider` section of configuration file specifies the authentication provider. The `name` field is REQUIRED for Ratify to bind to the correct provider implementation. 
 
 ## Example config.json
 ```
@@ -120,9 +120,9 @@ EOF
 ```
 
 ### 3. Kubernetes Secrets
-Ratify resolves registry credentials from [Docker Config Kubernetes secrets](https://kubernetes.io/docs/concepts/configuration/secret/#docker-config-secrets) in the cluster. Ratify considers kubernetes secrets in two ways. First, the configuration can specify a list of `secrets`. Each entry requires the `secretName` field. The `namespace` field must also be provided if the secret does not exist in the namespace Ratify is deployed in. The Ratify pod must be assigned the necessary read secret role in order to read the listed secrets from the namespace. Second, Ratify considers the `imagePullSecrets` specified in the service account associated with Ratify. The `serviceAccountName` field specifies the service account associated with Ratify. Ratify must be assigned a role to read the service account and secrets in the Ratify namespace.
+Ratify resolves registry credentials from [Docker Config Kubernetes secrets](https://kubernetes.io/docs/concepts/configuration/secret/#docker-config-secrets) in the cluster. Ratify considers kubernetes secrets in two ways. First, the configuration can specify a list of `secrets`. Each entry REQUIRES the `secretName` field. The `namespace` field MUST also be provided if the secret does not exist in the namespace Ratify is deployed in. The Ratify pod MUST be assigned the necessary read secret role in order to read the listed secrets from the namespace. Second, Ratify considers the `imagePullSecrets` specified in the service account associated with Ratify. The `serviceAccountName` field specifies the service account associated with Ratify. Ratify MUST be assigned a role to read the service account and secrets in the Ratify namespace.
 
-The Ratify helm chart contains a roles.yaml file with role assignments. If a namespace other than Ratify's namespace is provided, the user must add a new role binding to the cluster role so Ratify's service account can operate. 
+The Ratify helm chart contains a roles.yaml file with role assignments. If a namespace other than Ratify's namespace is provided, the user MUST add a new role binding to the cluster role so Ratify's service account can operate. 
 
 Ratify only supports the kubernetes.io/dockerconfigjson secret type or the legacy kubernetes.io/dockercfg type.  
 
@@ -142,3 +142,9 @@ Ratify only supports the kubernetes.io/dockerconfigjson secret type or the legac
     ]
 }
 ```
+
+## Notational Conventions
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" are to be interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
+
+The key words "unspecified", "undefined", and "implementation-defined" are to be interpreted as described in the [rationale for the C99 standard](http://www.open-std.org/jtc1/sc22/wg14/www/C99RationaleV5.10.pdf#page=18).

--- a/docs/oras-auth-provider.md
+++ b/docs/oras-auth-provider.md
@@ -1,0 +1,143 @@
+# ORAS Authentication Provider
+
+The ORAS referrer store is responsible for all registry and referrer resolution operations. In order for the ORAS referrer store to access referrer artifacts, authentication credentials must be provided to ORAS. Ratify contains multiple Authentication Providers to support different authentication scenarios within or outside of Kubernetes clusters. The user simply specifies which authentication provider to use in the configuration.
+
+In the configuration file, the user specifies the authentication provider in the `auth-provider` section. The `name` field is **required** to bind ratify to the correct provider implementation. 
+
+## Example config.json
+```
+{
+    "stores": {
+        "version": "1.0.0",
+        "plugins": [
+            {
+                "name": "oras",
+                "localCachePath": "./local_oras_cache",
+                "auth-provider": {
+                    "name": "<auth provider name>",
+                    <other provider specific fields>
+                }
+            }
+        ]
+    },
+    "verifiers": {
+        "version": "1.0.0",
+        "plugins": [
+            {
+                "name":"notaryv2",
+                "artifactTypes" : "application/vnd.cncf.notary.v2.signature",
+                "verificationCerts": [
+                    "<cert folder>"
+                  ]
+            }  
+        ]
+    }
+}
+```
+
+
+NOTE: If the authentication provider cannot resolve credentials for the specified registry host name, it will attempt to use anonymous credentials.
+
+## Supported Providers
+
+### 1. Docker Config
+This is the default authentication provider. If the `auth-provider` section is not specified in the configuration file, ratify will attempt to look for credentials at the default docker configuration path ($HOME/.docker/config.json).
+
+To specify a different docker config file path, the `docker-config` authentication provider can be defined in the configuration with the `configPath` field set. 
+
+```
+"auth-provider": {
+    "name": "docker-config",
+    "configPath": <custom file path string>
+}
+```
+
+### 2. Azure Workload Identity
+Using Workload Federated Identity in an Azure Kubernetes Service cluster, Ratify can pull artifacts from a private Azure Container Registry for verification. For an overview on how workload identity operates in Azure, refer to the [documentation](https://docs.microsoft.com/en-us/azure/active-directory/develop/workload-identity-federation). 
+
+#### User steps to set up Workload Identity with AKS and ACR:
+
+The official steps for setting up Workload Identity on AKS can be found [here](https://azure.github.io/azure-workload-identity/docs/quick-start.html).  
+
+1. Create ACR
+2. Create OIDC enabled AKS cluster by following steps [here](https://docs.microsoft.com/en-us/azure/aks/cluster-configuration#oidc-issuer-preview)
+3. Save the cluster's SERVICE_ACCOUNT_ISSUER (OIDC url): `az aks show --resource-group <resource_group> --name <cluster_name> --query "oidcIssuerProfile.issuerUrl" -otsv`
+4. Install Mutating Admission Webhook onto AKS cluster by following steps [here](https://azure.github.io/azure-workload-identity/docs/installation/mutating-admission-webhook.html)
+5. As the guide linked above shows, it's possible to use the AZ workload identity CLI or the regular az CLI to perform remaining setup. Following steps follow the AZ CLI.
+6. Create ACR AAD application: `az ad sp create-for-rbac --name "<APPLICATION_NAME>"`
+7. On Portal or AZ CLI, enable acrpull role to the AAD application for the ACR resource
+8. Use kubectl to add service account to cluster: 
+```
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    azure.workload.identity/client-id: ${APPLICATION_CLIENT_ID}
+  labels:
+    azure.workload.identity/use: "true"
+  name: ${SERVICE_ACCOUNT_NAME}
+  namespace: ${SERVICE_ACCOUNT_NAMESPACE}
+EOF
+```
+9. From Azure Cloud Shell: 
+```
+export APPLICATION_OBJECT_ID="$(az ad app show --id ${APPLICATION_CLIENT_ID} --query objectId -otsv)"
+cat <<EOF > body.json
+{
+  "name": "kubernetes-federated-credential",
+  "issuer": "${SERVICE_ACCOUNT_ISSUER}",
+  "subject": "system:serviceaccount:${SERVICE_ACCOUNT_NAMESPACE}:${SERVICE_ACCOUNT_NAME}",
+  "description": "Kubernetes service account federated credential",
+  "audiences": [
+    "api://AzureADTokenExchange"
+  ]
+}
+EOF
+
+az rest --method POST --uri "https://graph.microsoft.com/beta/applications/${APPLICATION_OBJECT_ID}/federatedIdentityCredentials" --body @body.json
+```
+10. In the Pod spec, add the `serviceAccountName` property. Example Pod spec:
+```
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: quick-start
+  namespace: <SERVICE_ACCOUNT_NAMESPACE>
+spec:
+  serviceAccountName: <SERVICE_ACCOUNT_NAME>
+  ...
+EOF
+```
+
+#### Ratify Auth Provider Configuration
+```
+"auth-provider": {
+    "name": "azure-wi"
+}
+```
+
+### 3. Kubernetes Secrets
+Registry credentials can be extracted from kubernetes secrets. Users can specify Docker Config Kubernetes secrets that exist in the cluster, and Ratify will resolve registry credentials using these secrets. The kuberentes secrets Ratify will consider are specified in two ways. First, a list of `secrets` can be specified in the configuration. Each entry will require the `secretName` to be specifed. If the secret does not exist in the namespace ratify is deployed in, the `namespace` field must also be provided. Second, the `imagePullSecrets` specified in the service account associated with Ratify will also be considered. The service account associated with Ratify can be specifed using the `serviceAccountName` field.
+
+Ratify only supports the kubernetes.io/dockerconfigjson secret type or the legacy kubernetes.io/dockercfg type.  
+
+#### Sample Configuration
+```
+"auth-provider": {
+    "name": "k8s-secrets",
+    "serviceAccountName": "ratify-sa", // will be 'default' if not specified
+    "secrets" : [
+        {
+            "secretName": "artifact-pull-docker-config" // ratify namespace will be used 
+        },
+        {
+            "secretName": "artifact-pull-docker-config2",
+            "namespace": "test"
+        }
+    ]
+}
+```
+
+NOTE: The provided Ratify Helm Chart consists of a roles.yaml file which establishes the necessary cluster role and role binding to the ratify namespace in order for ratify to read secrets and get the service account. If a namespace other than Ratify's namespace is provided, the user must add a new role binding to the cluster role so ratify's service account can operate. 

--- a/docs/oras-auth-provider.md
+++ b/docs/oras-auth-provider.md
@@ -76,6 +76,10 @@ The official steps for setting up Workload Identity on AKS can be found [here](h
 6. As the guide linked above shows, it's possible to use the AZ workload identity CLI or the regular az CLI to perform remaining setup. Following steps follow the AZ CLI.
 7. Create ACR AAD application: `az ad sp create-for-rbac --name "<APPLICATION_NAME>"`
 8. On Portal or AZ CLI, enable acrpull role to the AAD application for the ACR resource
+```
+// Sample AZ CLI command
+az role assignment create --assignee <AAD APPLICATION ID> --role acrpull --scope subscriptions/<SUBSCRIPTION NAME>/resourceGroups/<RESOURCE GROUP>/providers/Microsoft.ContainerRegistry/registries/<REGISTRY NAME>
+```
 9. Use kubectl to add service account to cluster: 
 ```
 cat <<EOF | kubectl apply -f -
@@ -139,7 +143,7 @@ EOF
 
 ### 3. Kubernetes Secrets
 Ratify resolves registry credentials from [Docker Config Kubernetes secrets](https://kubernetes.io/docs/concepts/configuration/secret/#docker-config-secrets) in the cluster. Ratify considers kubernetes secrets in two ways:
-1. The configuration can specify a list of `secrets`. Each entry REQUIRES the `secretName` field. The `namespace` field MUST also be provided if the secret does not exist in the namespace Ratify is deployed in. The Ratify helm chart contains a roles.yaml file with role assignments. If a namespace other than Ratify's namespace is provided in the secret list, the user MUST add a new role binding to the cluster role for that new namespace.
+1. The configuration can specify a list of `secrets`. Each entry REQUIRES the `secretName` field. The `namespace` field MUST also be provided if the secret does not exist in the namespace Ratify is deployed in. The Ratify helm chart contains a [roles.yaml](https://github.com/deislabs/ratify/blob/main/charts/ratify/templates/roles.yaml) file with role assignments. If a namespace other than Ratify's namespace is provided in the secret list, the user MUST add a new role binding to the cluster role for that new namespace.
 
 2. Ratify considers the `imagePullSecrets` specified in the service account associated with Ratify. The `serviceAccountName` field specifies the service account associated with Ratify. Ratify MUST be assigned a role to read the service account and secrets in the Ratify namespace.
 

--- a/docs/oras-auth-provider.md
+++ b/docs/oras-auth-provider.md
@@ -1,8 +1,8 @@
 # ORAS Authentication Provider
 
-The ORAS referrer store is responsible for all registry and referrer resolution operations. In order for the ORAS referrer store to access referrer artifacts, authentication credentials must be provided to ORAS. Ratify contains multiple Authentication Providers to support different authentication scenarios within or outside of Kubernetes clusters. The user simply specifies which authentication provider to use in the configuration.
+The ORAS referrer store handles all registry and referrer resolution operations. ORAS provides authentication credentials to access referrer artifacts. Ratify contains many Authentication Providers to support different authentication scenarios. The user specifies which authentication provider to use in the configuration.
 
-In the configuration file, the user specifies the authentication provider in the `auth-provider` section. The `name` field is **required** to bind ratify to the correct provider implementation. 
+The `auth-provider` section of configuration file specifies the authentication provider. Ratify **requires** the `name` field to bind to the correct provider implementation. 
 
 ## Example config.json
 ```
@@ -36,14 +36,14 @@ In the configuration file, the user specifies the authentication provider in the
 ```
 
 
-NOTE: If the authentication provider cannot resolve credentials for the specified registry host name, it will attempt to use anonymous credentials.
+NOTE: The authentication provider attempts to use anonymous credentials if it fails to resolve credentials
 
 ## Supported Providers
 
 ### 1. Docker Config
-This is the default authentication provider. If the `auth-provider` section is not specified in the configuration file, ratify will attempt to look for credentials at the default docker configuration path ($HOME/.docker/config.json).
+This is the default authentication provider. Ratify attempts to look for credentials at the default docker configuration path ($HOME/.docker/config.json) if the `auth-provider` section is not specified.
 
-To specify a different docker config file path, the `docker-config` authentication provider can be defined in the configuration with the `configPath` field set. 
+Specify the `configPath` field for the `docker-config` authentication provider to use a different docker config file path. 
 
 ```
 "auth-provider": {
@@ -53,7 +53,7 @@ To specify a different docker config file path, the `docker-config` authenticati
 ```
 
 ### 2. Azure Workload Identity
-Using Workload Federated Identity in an Azure Kubernetes Service cluster, Ratify can pull artifacts from a private Azure Container Registry for verification. For an overview on how workload identity operates in Azure, refer to the [documentation](https://docs.microsoft.com/en-us/azure/active-directory/develop/workload-identity-federation). 
+Ratify pulls artifacts from a private Azure Container Registry using Workload Federated Identity in an Azure Kubernetes Service cluster. For an overview on how workload identity operates in Azure, refer to the [documentation](https://docs.microsoft.com/en-us/azure/active-directory/develop/workload-identity-federation). 
 
 #### User steps to set up Workload Identity with AKS and ACR:
 
@@ -61,12 +61,13 @@ The official steps for setting up Workload Identity on AKS can be found [here](h
 
 1. Create ACR
 2. Create OIDC enabled AKS cluster by following steps [here](https://docs.microsoft.com/en-us/azure/aks/cluster-configuration#oidc-issuer-preview)
-3. Save the cluster's SERVICE_ACCOUNT_ISSUER (OIDC url): `az aks show --resource-group <resource_group> --name <cluster_name> --query "oidcIssuerProfile.issuerUrl" -otsv`
-4. Install Mutating Admission Webhook onto AKS cluster by following steps [here](https://azure.github.io/azure-workload-identity/docs/installation/mutating-admission-webhook.html)
-5. As the guide linked above shows, it's possible to use the AZ workload identity CLI or the regular az CLI to perform remaining setup. Following steps follow the AZ CLI.
-6. Create ACR AAD application: `az ad sp create-for-rbac --name "<APPLICATION_NAME>"`
-7. On Portal or AZ CLI, enable acrpull role to the AAD application for the ACR resource
-8. Use kubectl to add service account to cluster: 
+3. Connect to cluster using kubectl by following steps [here](https://docs.microsoft.com/en-us/azure/aks/tutorial-kubernetes-deploy-cluster?tabs=azure-cli#connect-to-cluster-using-kubectl)
+4. Save the cluster's SERVICE_ACCOUNT_ISSUER (OIDC url): `az aks show --resource-group <resource_group> --name <cluster_name> --query "oidcIssuerProfile.issuerUrl" -otsv`
+5. Install Mutating Admission Webhook onto AKS cluster by following steps [here](https://azure.github.io/azure-workload-identity/docs/installation/mutating-admission-webhook.html)
+6. As the guide linked above shows, it's possible to use the AZ workload identity CLI or the regular az CLI to perform remaining setup. Following steps follow the AZ CLI.
+7. Create ACR AAD application: `az ad sp create-for-rbac --name "<APPLICATION_NAME>"`
+8. On Portal or AZ CLI, enable acrpull role to the AAD application for the ACR resource
+9. Use kubectl to add service account to cluster: 
 ```
 cat <<EOF | kubectl apply -f -
 apiVersion: v1
@@ -80,7 +81,7 @@ metadata:
   namespace: ${SERVICE_ACCOUNT_NAMESPACE}
 EOF
 ```
-9. From Azure Cloud Shell: 
+10. From Azure Cloud Shell: 
 ```
 export APPLICATION_OBJECT_ID="$(az ad app show --id ${APPLICATION_CLIENT_ID} --query objectId -otsv)"
 cat <<EOF > body.json
@@ -97,7 +98,7 @@ EOF
 
 az rest --method POST --uri "https://graph.microsoft.com/beta/applications/${APPLICATION_OBJECT_ID}/federatedIdentityCredentials" --body @body.json
 ```
-10. In the Pod spec, add the `serviceAccountName` property. Example Pod spec:
+11. In the Pod spec, add the `serviceAccountName` property. Example Pod spec:
 ```
 cat <<EOF | kubectl apply -f -
 apiVersion: v1
@@ -119,7 +120,7 @@ EOF
 ```
 
 ### 3. Kubernetes Secrets
-Registry credentials can be extracted from kubernetes secrets. Users can specify Docker Config Kubernetes secrets that exist in the cluster, and Ratify will resolve registry credentials using these secrets. The kuberentes secrets Ratify will consider are specified in two ways. First, a list of `secrets` can be specified in the configuration. Each entry will require the `secretName` to be specifed. If the secret does not exist in the namespace ratify is deployed in, the `namespace` field must also be provided. Second, the `imagePullSecrets` specified in the service account associated with Ratify will also be considered. The service account associated with Ratify can be specifed using the `serviceAccountName` field.
+Ratify resolves registry credentials from Docker Config Kubernetes secrets in the cluster. Ratify considers kubernetes secrets in two ways. First, the configuration can specify a list of `secrets`. Each entry requires the `secretName` field. The `namespace` field must also be provided if the secret does not exist in the namespace ratify is deployed in. Second, Ratify considers the `imagePullSecrets` specified in the service account associated with Ratify. The  `serviceAccountName` field specifies the service account associated with Ratify.
 
 Ratify only supports the kubernetes.io/dockerconfigjson secret type or the legacy kubernetes.io/dockercfg type.  
 
@@ -140,4 +141,4 @@ Ratify only supports the kubernetes.io/dockerconfigjson secret type or the legac
 }
 ```
 
-NOTE: The provided Ratify Helm Chart consists of a roles.yaml file which establishes the necessary cluster role and role binding to the ratify namespace in order for ratify to read secrets and get the service account. If a namespace other than Ratify's namespace is provided, the user must add a new role binding to the cluster role so ratify's service account can operate. 
+NOTE: The provided Ratify Helm Chart consists of a roles.yaml file which establishes the necessary cluster role and role binding to the ratify namespace. This allows ratify to read secrets and get the service account. If a namespace other than Ratify's namespace is provided, the user must add a new role binding to the cluster role so ratify's service account can operate. 

--- a/docs/oras-auth-provider.md
+++ b/docs/oras-auth-provider.md
@@ -1,6 +1,6 @@
 # ORAS Authentication Provider
 
-The ORAS referrer store handles all registry and referrer resolution operations. ORAS provides authentication credentials to access referrer artifacts. Ratify contains many Authentication Providers to support different authentication scenarios. The user specifies which authentication provider to use in the configuration.
+ORAS handles all referrer operations using registry as the referrer store. It uses authentication credentials to authenticate to a registry and access referrer artifacts. Ratify contains many Authentication Providers to support different authentication scenarios. The user specifies which authentication provider to use in the configuration.
 
 The `auth-provider` section of configuration file specifies the authentication provider. Ratify **requires** the `name` field to bind to the correct provider implementation. 
 
@@ -36,7 +36,7 @@ The `auth-provider` section of configuration file specifies the authentication p
 ```
 
 
-NOTE: The authentication provider attempts to use anonymous credentials if it fails to resolve credentials
+NOTE: ORAS will attempt to use anonymous access if the authentication provider fails to resolve credentials.
 
 ## Supported Providers
 
@@ -120,7 +120,9 @@ EOF
 ```
 
 ### 3. Kubernetes Secrets
-Ratify resolves registry credentials from Docker Config Kubernetes secrets in the cluster. Ratify considers kubernetes secrets in two ways. First, the configuration can specify a list of `secrets`. Each entry requires the `secretName` field. The `namespace` field must also be provided if the secret does not exist in the namespace ratify is deployed in. Second, Ratify considers the `imagePullSecrets` specified in the service account associated with Ratify. The  `serviceAccountName` field specifies the service account associated with Ratify.
+Ratify resolves registry credentials from [Docker Config Kubernetes secrets](https://kubernetes.io/docs/concepts/configuration/secret/#docker-config-secrets) in the cluster. Ratify considers kubernetes secrets in two ways. First, the configuration can specify a list of `secrets`. Each entry requires the `secretName` field. The `namespace` field must also be provided if the secret does not exist in the namespace Ratify is deployed in. The Ratify pod must be assigned the necessary read secret role in order to read the listed secrets from the namespace. Second, Ratify considers the `imagePullSecrets` specified in the service account associated with Ratify. The `serviceAccountName` field specifies the service account associated with Ratify. Ratify must be assigned a role to read the service account and secrets in the Ratify namespace.
+
+The Ratify helm chart contains a roles.yaml file with role assignments. If a namespace other than Ratify's namespace is provided, the user must add a new role binding to the cluster role so Ratify's service account can operate. 
 
 Ratify only supports the kubernetes.io/dockerconfigjson secret type or the legacy kubernetes.io/dockercfg type.  
 
@@ -131,7 +133,7 @@ Ratify only supports the kubernetes.io/dockerconfigjson secret type or the legac
     "serviceAccountName": "ratify-sa", // will be 'default' if not specified
     "secrets" : [
         {
-            "secretName": "artifact-pull-docker-config" // ratify namespace will be used 
+            "secretName": "artifact-pull-docker-config" // Ratify namespace will be used 
         },
         {
             "secretName": "artifact-pull-docker-config2",
@@ -140,5 +142,3 @@ Ratify only supports the kubernetes.io/dockerconfigjson secret type or the legac
     ]
 }
 ```
-
-NOTE: The provided Ratify Helm Chart consists of a roles.yaml file which establishes the necessary cluster role and role binding to the ratify namespace. This allows ratify to read secrets and get the service account. If a namespace other than Ratify's namespace is provided, the user must add a new role binding to the cluster role so ratify's service account can operate. 


### PR DESCRIPTION
- Adds documentation for ORAS Auth Provider
- Currently has user guides for default docker-config, azure workload identity, and k8s secrets

Should wait for #137 to be completed before merging

Closes #143 
Closes #144 