### PR TITLE
Adding Auth Provider Templates to Chart

### DIFF
--- a/charts/ratify/templates/configmap.yaml
+++ b/charts/ratify/templates/configmap.yaml
@@ -14,13 +14,13 @@ data:
                 ,
                 "cosign-enabled": true
                 {{- end }}
-                {{- if .Values.oras.authProviders.azureWorkloadIdentity }}
+                {{- if .Values.oras.authProviders.azureWorkloadIdentityEnabled }}
                 ,
                 "auth-provider": {
                     "name": "azure-wi"
                 }
                 {{- end }}
-                {{- if .Values.oras.authProviders.k8secrets }}
+                {{- if .Values.oras.authProviders.k8secretsEnabled }}
                 ,
                 "auth-provider": {
                     "name": "k8secrets"

--- a/charts/ratify/templates/configmap.yaml
+++ b/charts/ratify/templates/configmap.yaml
@@ -14,6 +14,18 @@ data:
                 ,
                 "cosign-enabled": true
                 {{- end }}
+                {{- if .Values.oras.authProviders.azurewi }}
+                ,
+                "auth-provider": {
+                    "name": "azure-wi"
+                }
+                {{- end }}
+                {{- if .Values.oras.authProviders.k8secrets }}
+                ,
+                "auth-provider": {
+                    "name": "k8secrets"
+                }
+                {{- end }}
             }
         ]
       },

--- a/charts/ratify/templates/configmap.yaml
+++ b/charts/ratify/templates/configmap.yaml
@@ -14,7 +14,7 @@ data:
                 ,
                 "cosign-enabled": true
                 {{- end }}
-                {{- if .Values.oras.authProviders.azurewi }}
+                {{- if .Values.oras.authProviders.azureWorkloadIdentity }}
                 ,
                 "auth-provider": {
                     "name": "azure-wi"

--- a/charts/ratify/values.yaml
+++ b/charts/ratify/values.yaml
@@ -42,5 +42,5 @@ akvCertConfig:
   aadPodIdentity:
 oras:
   authProviders:
-    azurewi: false
+    azureWorkloadIdentity: false
     k8secrets: false

--- a/charts/ratify/values.yaml
+++ b/charts/ratify/values.yaml
@@ -42,5 +42,5 @@ akvCertConfig:
   aadPodIdentity:
 oras:
   authProviders:
-    azureWorkloadIdentity: false
-    k8secrets: false
+    azureWorkloadIdentityEnabled: false
+    k8secretsEnabled: false

--- a/charts/ratify/values.yaml
+++ b/charts/ratify/values.yaml
@@ -40,3 +40,7 @@ akvCertConfig:
   certName:
   tenantId:
   aadPodIdentity:
+oras:
+  authProviders:
+    azurewi: false
+    k8secrets: false


### PR DESCRIPTION
- add azure workload identity and k8s secrets auth providers in config map
- templatized so the provider used is determined by flags in values.yaml