### PR TITLE
Add Auth Cache Eviction

### DIFF
--- a/pkg/referrerstore/oras/oras.go
+++ b/pkg/referrerstore/oras/oras.go
@@ -291,7 +291,7 @@ func (store *orasStore) createRepository(ctx context.Context, targetRef common.R
 	if cacheEntry, ok := store.authCache[targetRef.Original]; ok {
 		// if the auth cache entry expiration has not expired or it was never set
 		if cacheEntry.expiresOn.IsZero() || cacheEntry.expiresOn.After(time.Now()) {
-			return cacheEntry.client, time.Now(), nil
+			return cacheEntry.client, cacheEntry.expiresOn, nil
 		}
 	}
 

--- a/pkg/referrerstore/oras/oras.go
+++ b/pkg/referrerstore/oras/oras.go
@@ -361,7 +361,6 @@ func (store *orasStore) getRawContentFromCache(ctx context.Context, descriptor o
 func (store *orasStore) addAuthCache(ref string, repository *remote.Repository, expiry time.Time) {
 	_, ok := store.authCache[ref]
 	if !ok {
-		logrus.Infof("adding repo to the auth cache: %s", ref)
 		store.authCache[ref] = authCacheEntry{
 			client:    repository,
 			expiresOn: expiry,
@@ -370,8 +369,11 @@ func (store *orasStore) addAuthCache(ref string, repository *remote.Repository, 
 }
 
 func (store *orasStore) evictAuthCache(ref string, err error) {
-	if strings.Contains(err.Error(), "code 401") {
-		logrus.Infof("evicting from the auth cache: %s", ref)
-		delete(store.authCache, ref)
+	err_codes := []int{400, 401, 403}
+	for code := range err_codes {
+		if strings.Contains(err.Error(), fmt.Sprintf("code %d", code)) {
+			delete(store.authCache, ref)
+			break
+		}
 	}
 }

--- a/pkg/referrerstore/oras/oras.go
+++ b/pkg/referrerstore/oras/oras.go
@@ -24,7 +24,6 @@ import (
 	"io"
 	"net/http"
 	paths "path/filepath"
-	"strings"
 	"time"
 
 	oci "github.com/opencontainers/image-spec/specs-go/v1"
@@ -369,11 +368,6 @@ func (store *orasStore) addAuthCache(ref string, repository *remote.Repository, 
 }
 
 func (store *orasStore) evictAuthCache(ref string, err error) {
-	err_codes := []int{400, 401, 403}
-	for code := range err_codes {
-		if strings.Contains(err.Error(), fmt.Sprintf("code %d", code)) {
-			delete(store.authCache, ref)
-			break
-		}
-	}
+	delete(store.authCache, ref)
+	// TODO: add reliable way to conditionally evict based on error code
 }


### PR DESCRIPTION
- Evicts the repository from the authentication cache if any of the ORAS operations returns a 401 error
- This allows for credential Provide process to re populate the cache the next retry