### PR TITLE
Fix isSuccess not showing in output

### DIFF
--- a/pkg/verifier/api.go
+++ b/pkg/verifier/api.go
@@ -27,7 +27,7 @@ import (
 // VerifierResult describes the result of verifying a reference manifest for a subject
 type VerifierResult struct {
 	Subject       string           `json:"subject,omitempty"`
-	IsSuccess     bool             `json:"isSuccess,omitempty"`
+	IsSuccess     bool             `json:"isSuccess"`
 	Name          string           `json:"name,omitempty"`
 	Results       []string         `json:"results,omitempty"`
 	NestedResults []VerifierResult `json:"nestedResults,omitempty"`

--- a/pkg/verifier/factory/factory_test.go
+++ b/pkg/verifier/factory/factory_test.go
@@ -45,7 +45,7 @@ func (s *TestVerifier) Verify(ctx context.Context,
 	referenceDescriptor ocispecs.ReferenceDescriptor,
 	referrerStore referrerstore.ReferrerStore,
 	executor executor.Executor) (verifier.VerifierResult, error) {
-	return verifier.VerifierResult{}, nil
+	return verifier.VerifierResult{IsSuccess: false}, nil
 }
 
 func (f *TestVerifierFactory) Create(version string, verifierConfig config.VerifierConfig) (verifier.ReferenceVerifier, error) {

--- a/pkg/verifier/notaryv2/notaryv2.go
+++ b/pkg/verifier/notaryv2/notaryv2.go
@@ -113,19 +113,19 @@ func (v *notaryV2Verifier) Verify(ctx context.Context,
 	referenceManifest, err := store.GetReferenceManifest(ctx, subjectReference, referenceDescriptor)
 
 	if err != nil {
-		return verifier.VerifierResult{}, err
+		return verifier.VerifierResult{IsSuccess: false}, err
 	}
 
 	for _, blobDesc := range referenceManifest.Blobs {
 		refBlob, err := store.GetBlobContent(ctx, subjectReference, blobDesc.Digest, blobDesc)
 		if err != nil {
-			return verifier.VerifierResult{}, err
+			return verifier.VerifierResult{IsSuccess: false}, err
 		}
 
 		var opts notation.VerifyOptions
 		vdesc, err := v.notationVerifier.Verify(context.Background(), refBlob, opts)
 		if err != nil {
-			return verifier.VerifierResult{}, err
+			return verifier.VerifierResult{IsSuccess: false}, err
 		}
 
 		// TODO get the subject descriptor and verify all the properties other than digest.

--- a/pkg/verifier/plugin/plugin.go
+++ b/pkg/verifier/plugin/plugin.go
@@ -104,7 +104,7 @@ func (vp *VerifierPlugin) Verify(ctx context.Context,
 		nestedVerifyResult, err := executor.VerifySubject(ctx, verifyParameters)
 
 		if err != nil {
-			return verifier.VerifierResult{}, err
+			return verifier.VerifierResult{IsSuccess: false}, err
 		}
 
 		for _, vr := range nestedVerifyResult.VerifierReports {
@@ -127,7 +127,7 @@ func (vp *VerifierPlugin) Verify(ctx context.Context,
 	referrerStoreConfig := store.GetConfig()
 	vr, err := vp.verifyReference(ctx, subjectReference, referenceDescriptor, referrerStoreConfig)
 	if err != nil {
-		return verifier.VerifierResult{}, err
+		return verifier.VerifierResult{IsSuccess: false}, err
 	}
 
 	vr.NestedResults = nestedResults


### PR DESCRIPTION
- The individual verifier report would fail to show `isSuccess` as false. This was due to the default false value being omitted in the JSON decoding process. Refer to https://github.com/golang/go/issues/13284 for Go encoding issue.
- Resolved by removing `omitEmpty` and adding isSuccess: false explicitly where it was missing

Partially Fixes #152 