### PR TITLE
CSI Driver template update for workload identity

### DIFF
--- a/charts/ratify/templates/akv-secret-provider.yaml
+++ b/charts/ratify/templates/akv-secret-provider.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   provider: azure
   parameters:
-    usePodIdentity: "true"
     keyvaultName: {{ required "vaultName must be provided when AKV cert config is enabled" .Values.akvCertConfig.vaultName  }}
     objects:  |
       array:
@@ -15,4 +14,5 @@ spec:
           objectType: cert
           objectAlias: ratify-test.crt
     tenantId: {{ required "tenantId must be provided when AKV cert config is enabled" .Values.akvCertConfig.tenantId  }}
+    clientID: {{ required "clientID must be provided when AKV cert config is enabled" .Values.akvCertConfig.clientId  }}
 {{ end }}

--- a/charts/ratify/templates/deployment.yaml
+++ b/charts/ratify/templates/deployment.yaml
@@ -14,10 +14,10 @@ spec:
     metadata:
       labels:
         {{- include "ratify.selectorLabels" . | nindent 8 }}
-        {{- if .Values.akvCertConfig.enabled }}
-        aadpodidbinding: {{ required "aadPodIdentity must be provided when AKV cert config is enabled" .Values.akvCertConfig.aadPodIdentity  }}
-        {{- end }}
     spec:
+      {{- if or (.Values.akvCertConfig.enabled) (.Values.oras.authProviders.azureWorkloadIdentityEnabled)}} 
+      serviceAccountName: {{ required "service account must be provided when using workload identity for AKV cert config or oras authentication" .Values.serviceAccount.name  }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/ratify/values.yaml
+++ b/charts/ratify/values.yaml
@@ -39,7 +39,7 @@ akvCertConfig:
   vaultName:
   certName:
   tenantId:
-  aadPodIdentity:
+  clientId:
 oras:
   authProviders:
     azureWorkloadIdentityEnabled: false


### PR DESCRIPTION
 update CSI driver to use also use workload identity so user won't have to configure workload identity as well as pod identity.