### PR TITLE
Update validating webhook timeout to 7 seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ by its developers, nor is it "supported" software.
 
 Try out ratify in Kuberenetes through Gatekeeper as the admission controller.
 
+Prerequisite: Kubernetes v1.20 or higher
+
 - Setup Gatekeeper with [external data](https://open-policy-agent.github.io/gatekeeper/website/docs/externaldata)
 
 ```bash
@@ -38,7 +40,7 @@ helm install gatekeeper/gatekeeper  \
     --set validatingWebhookTimeoutSeconds=7
 ```
 
-(NOTE: `validatingWebhookTimeoutSeconds` increased from 3 to 7 so all Ratify operations complete in complex scenarios)
+NOTE: `validatingWebhookTimeoutSeconds` increased from 3 to 7 so all Ratify operations complete in complex scenarios. Kubernetes v1.20 or higher is REQUIRED to increase timeout.  
 
 - Deploy ratify and a `demo` constraint on gatekeeper
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ helm install gatekeeper/gatekeeper  \
     --name-template=gatekeeper \
     --namespace gatekeeper-system --create-namespace \
     --set enableExternalData=true \
-    --set controllerManager.dnsPolicy=ClusterFirst,audit.dnsPolicy=ClusterFirst
+    --set controllerManager.dnsPolicy=ClusterFirst,audit.dnsPolicy=ClusterFirst \
+    --set validatingWebhookTimeoutSeconds=7
 ```
 
 - Deploy ratify and a `demo` constraint on gatekeeper

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ helm install gatekeeper/gatekeeper  \
     --set validatingWebhookTimeoutSeconds=7
 ```
 
+(NOTE: `validatingWebhookTimeoutSeconds` increased from 3 to 7 so all Ratify operations complete in complex scenarios)
+
 - Deploy ratify and a `demo` constraint on gatekeeper
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ helm install gatekeeper/gatekeeper  \
     --name-template=gatekeeper \
     --namespace gatekeeper-system --create-namespace \
     --set enableExternalData=true \
-    --set controllerManager.dnsPolicy=ClusterFirst,audit.dnsPolicy=ClusterFirst \
     --set validatingWebhookTimeoutSeconds=7
 ```
 

--- a/charts/ratify-gatekeeper/values.yaml
+++ b/charts/ratify-gatekeeper/values.yaml
@@ -8,7 +8,7 @@ gatekeeper:
   auditFromCache: false
   disableMutation: false
   disableValidatingWebhook: false
-  validatingWebhookTimeoutSeconds: 3
+  validatingWebhookTimeoutSeconds: 7
   validatingWebhookFailurePolicy: Ignore
   validatingWebhookCheckIgnoreFailurePolicy: Fail
   enableDeleteOperations: false

--- a/charts/ratify/templates/configmap.yaml
+++ b/charts/ratify/templates/configmap.yaml
@@ -5,6 +5,9 @@ metadata:
 data:
   config.json: |
     {
+      "executor": {
+        "requestTimeout": 6800
+      },
       "stores": {
         "version": "1.0.0",
         "plugins": [

--- a/cmd/ratify/cmd/serve.go
+++ b/cmd/ratify/cmd/serve.go
@@ -92,6 +92,7 @@ func serve(opts serveCmdOptions) error {
 		Verifiers:      verifiers,
 		ReferrerStores: stores,
 		PolicyEnforcer: policyEnforcer,
+		Config:         &cf.ExecutorConfig,
 	}
 
 	if opts.httpServerAddress != "" {


### PR DESCRIPTION
- update configmap, and README to set validating webhook timeout to 7 seconds
- add executor config to set timeout to 6800ms

Related Gatekeeper issue: https://github.com/open-policy-agent/gatekeeper/issues/1956