### PR TITLE
workflow to publish helm chart as github page

### DIFF
--- a/.github/workflows/publish-charts.yml
+++ b/.github/workflows/publish-charts.yml
@@ -1,0 +1,15 @@
+name: publishChart
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish Helm charts
+        uses: stefanprodan/helm-gh-pages@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
adding a workflow to publish helm chart as github page as suggested in https://github.com/deislabs/ratify/issues/85
This workflow will publish charts directory to default branch gh-pages

After merging this PR, a branch with name "gh-pages" needs to be created and configured as the github page branch.

Customer will be able to install ratify without cloning ratify repo. Sample commands below from testing with my fork:
 
helm repo add ratify https://susanshi.github.io/ratify
helm install ratify ratify/ratify --atomic
kubectl apply -f https://susanshi.github.io/ratify/charts/ratify-gatekeeper/templates/constraint.yaml

closes #85 