### PR TITLE
Bump Releaser to Go 1.17

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16
+        go-version: 1.17
 
     - name: Goreleaser
       uses: goreleaser/goreleaser-action@v2


### PR DESCRIPTION
- update go releaser.yml file to use 1.17