### PR TITLE
Create Service Account for Azure Workload ID in Helm chart

### DIFF
--- a/charts/ratify/templates/_helpers.tpl
+++ b/charts/ratify/templates/_helpers.tpl
@@ -61,7 +61,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "ratify.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+{{- if or .Values.oras.authProviders.azureWorkloadIdentity.enabled .Values.serviceAccount.create }}
 {{- default (include "ratify.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}

--- a/charts/ratify/templates/azwi-serviceaccount.yaml
+++ b/charts/ratify/templates/azwi-serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if (or .Values.oras.authProviders.azureWorkloadIdentity.enabled .Values.serviceAccount.create) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    {{- include "ratify.labels" . | nindent 4 }}
+  {{- if .Values.oras.authProviders.azureWorkloadIdentity.enabled }}
+    azure.workload.identity/use: "true"
+  annotations:
+    azure.workload.identity/client-id: {{ .Values.oras.authProviders.azureWorkloadIdentity.clientId }}
+  {{- end }}
+  name: {{ include "ratify.serviceAccountName" . }}
+{{- end }}

--- a/charts/ratify/templates/configmap.yaml
+++ b/charts/ratify/templates/configmap.yaml
@@ -17,7 +17,7 @@ data:
                 ,
                 "cosign-enabled": true
                 {{- end }}
-                {{- if .Values.oras.authProviders.azureWorkloadIdentityEnabled }}
+                {{- if .Values.oras.authProviders.azureWorkloadIdentity.enabled }}
                 ,
                 "auth-provider": {
                     "name": "azure-wi"

--- a/charts/ratify/templates/deployment.yaml
+++ b/charts/ratify/templates/deployment.yaml
@@ -15,8 +15,8 @@ spec:
       labels:
         {{- include "ratify.selectorLabels" . | nindent 8 }}
     spec:
-      {{- if or (.Values.akvCertConfig.enabled) (.Values.oras.authProviders.azureWorkloadIdentity.enabled)}} 
-      serviceAccountName: {{ required "service account must be provided when using workload identity for AKV cert config or oras authentication" .Values.oras.authProviders.azureWorkloadIdentity.serviceAccountName  }}
+      {{- if or (or .Values.akvCertConfig.enabled .Values.oras.authProviders.azureWorkloadIdentity.enabled) .Values.serviceAccount.create }}
+      serviceAccountName: {{ required "service account must be provided when using workload identity for AKV cert config or oras authentication" (include "ratify.serviceAccountName" .) }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/charts/ratify/templates/deployment.yaml
+++ b/charts/ratify/templates/deployment.yaml
@@ -15,8 +15,8 @@ spec:
       labels:
         {{- include "ratify.selectorLabels" . | nindent 8 }}
     spec:
-      {{- if or (.Values.akvCertConfig.enabled) (.Values.oras.authProviders.azureWorkloadIdentityEnabled)}} 
-      serviceAccountName: {{ required "service account must be provided when using workload identity for AKV cert config or oras authentication" .Values.serviceAccount.name  }}
+      {{- if or (.Values.akvCertConfig.enabled) (.Values.oras.authProviders.azureWorkloadIdentity.enabled)}} 
+      serviceAccountName: {{ required "service account must be provided when using workload identity for AKV cert config or oras authentication" .Values.oras.authProviders.azureWorkloadIdentity.serviceAccountName  }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/charts/ratify/values.yaml
+++ b/charts/ratify/values.yaml
@@ -34,6 +34,9 @@ resources:
    requests:
      cpu: 100m
      memory: 128Mi
+serviceAccount:
+  create: false
+  name:
 akvCertConfig:
   enabled: false
   vaultName:
@@ -45,5 +48,5 @@ oras:
   authProviders:
     azureWorkloadIdentity:
       enabled: false
-      serviceAccountName:
+      clientId:
     k8secretsEnabled: false

--- a/charts/ratify/values.yaml
+++ b/charts/ratify/values.yaml
@@ -43,5 +43,7 @@ akvCertConfig:
   clientId:
 oras:
   authProviders:
-    azureWorkloadIdentityEnabled: false
+    azureWorkloadIdentity:
+      enabled: false
+      serviceAccountName:
     k8secretsEnabled: false


### PR DESCRIPTION
This PR updates the Helm chart:

- Adds a service account that will be created if a) the user sets `oras.authProviders.azureWorkloadIdentity.enabled=true` or b) the user sets `serviceAccount.create=true` (this one is pretty standard helm chart stuff that looks like it was partially removed at some point in development - I re-added it rather than removing the bulk of the helper function for `ratify.serviceAccountName` as it's convenient to have around.
- Adds `serviceAccount.create` and `serviceAccount.name` back to the values files in accordance with the above
- Updates the `oras.authProviders.azureWorkloadIdentity` field in the values file to add a variable for clientId and to split out `azureWorkloadIdentityEnabled` into `azureWorkloadIdentity.enabled`
- Updates the deployment and configmap in accordance with the above changes.

Happy to make further changes as needed, just let me know!