### PR TITLE
Update hardcoded URL in provider.yaml to allow flexibility with regard to namespace

### DIFF
--- a/charts/ratify/templates/provider.yaml
+++ b/charts/ratify/templates/provider.yaml
@@ -3,5 +3,5 @@ kind: Provider
 metadata:
   name: ratify-provider
 spec:
-  url: "http://ratify-svc.default:6001/ratify/gatekeeper/v1/verify"
+  url: "http://{{ include "ratify.fullname" .}}.{{ .Release.Namespace }}:6001/ratify/gatekeeper/v1/verify"
   timeout: 100

--- a/charts/ratify/templates/service.yaml
+++ b/charts/ratify/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: ratify-svc
+  name: {{ include "ratify.fullname" . }}
   labels:
     {{- include "ratify.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
At current the provider.yaml file in the Helm chart sets a ratify URL that ties it to the default namespace even if the chart is deployed in another namespace. This should make it align with any namespace.