### PR TITLE
Fix for Issue 207 - spec SA by name

### DIFF
--- a/charts/ratify/templates/deployment.yaml
+++ b/charts/ratify/templates/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       labels:
         {{- include "ratify.selectorLabels" . | nindent 8 }}
     spec:
-      {{- if or .Values.azureWorkloadIdentity.clientId .Values.serviceAccount.create }}
+      {{- if or .Values.azureWorkloadIdentity.clientId .Values.serviceAccount.create .Values.serviceAccount.name }}
       serviceAccountName: {{ include "ratify.serviceAccountName" . }}
       {{- end }}
       containers:


### PR DESCRIPTION
Added `.Values.serviceAccount.name` to be able to spec SA name in Deployment resource, without creating the SA. This will allow processes, outside of the helm chart, to create SA used by the helm chart.

Closes #207 