### PR TITLE
[Bugfix] Update K8 Secret Auth Provider Name

### DIFF
--- a/charts/ratify/templates/configmap.yaml
+++ b/charts/ratify/templates/configmap.yaml
@@ -26,7 +26,7 @@ data:
                 {{- if .Values.oras.authProviders.k8secretsEnabled }}
                 ,
                 "auth-provider": {
-                    "name": "k8secrets"
+                    "name": "k8s-secrets"
                 }
                 {{- end }}
             }


### PR DESCRIPTION
- The config map's k8s secret auth provider name was incorrect. This PR updates to the correct name.

