### PR TITLE
Update go releaser template to use go mod tidy 1.17 compat

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,7 @@
 # Check the documentation at https://goreleaser.com for more options
 before:
   hooks:
-    - go mod tidy
+    - go mod tidy -compat=1.17
 builds:
   - id: ratify
     dir: cmd/ratify


### PR DESCRIPTION
Update go releaser yaml to user go mod tidy --compat=1.17