### PR TITLE
Add GH Page Sync Workflow

### DIFF
--- a/.github/workflows/sync-gh-pages.yml
+++ b/.github/workflows/sync-gh-pages.yml
@@ -1,0 +1,18 @@
+name: Sync GH Pages
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - library/**
+jobs:
+  merge-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: everlytic/branch-merge@1.1.2
+        with:
+          github_token: ${{ github.token }}
+          source_ref: ${{ github.ref }}
+          target_branch: 'gh-page'
+          commit_message_template: '[Automated] Merged {source_ref} into target {target_branch}'

--- a/.github/workflows/sync-gh-pages.yml
+++ b/.github/workflows/sync-gh-pages.yml
@@ -14,5 +14,5 @@ jobs:
         with:
           github_token: ${{ github.token }}
           source_ref: ${{ github.ref }}
-          target_branch: 'gh-page'
+          target_branch: 'gh-pages'
           commit_message_template: '[Automated] Merged {source_ref} into target {target_branch}'


### PR DESCRIPTION
# Description

- Merges 'main' branch into 'gh-pages' branch on push to 'main' only when 'library/**' directory is changed
- NOTE: this will kick off a new gh page publish action every time a change to 'libary/**' folder is merged to main. NOT just on release.

Fixes #273 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- Tested with personal fork of Ratify and simulated push flow to library folder

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?
