### PR TITLE
Add default path for notaryv2 certificates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ build-plugins:
 .PHONY: install
 install: 
 	mkdir -p ${INSTALL_DIR}
+	mkdir -p ${INSTALL_DIR}/ratify-certs
 	cp -r ./bin/* ${INSTALL_DIR}
 
 .PHONY: test

--- a/config/config.json
+++ b/config/config.json
@@ -24,10 +24,7 @@
         "plugins": [
             {
                 "name":"notaryv2",
-                "artifactTypes" : "application/vnd.cncf.notary.v2.signature",
-                "verificationCerts": [
-                    "<cert folder>"
-                  ]
+                "artifactTypes" : "application/vnd.cncf.notary.v2.signature"
             },
             {
                 "name":"sbom",

--- a/pkg/verifier/notaryv2/notaryv2.go
+++ b/pkg/verifier/notaryv2/notaryv2.go
@@ -72,7 +72,6 @@ func (f *notaryv2VerifierFactory) Create(version string, verifierConfig config.V
 		return nil, err
 	}
 
-	//fmt.Print("test\n")
 	if err := json.Unmarshal(verifierConfigBytes, &conf); err != nil {
 		return nil, fmt.Errorf("failed to parse config for the input: %v", err)
 	}

--- a/pkg/verifier/notaryv2/notaryv2.go
+++ b/pkg/verifier/notaryv2/notaryv2.go
@@ -21,10 +21,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	paths "path/filepath"
 	"strings"
 
+	ratifyconfig "github.com/deislabs/ratify/config"
 	"github.com/deislabs/ratify/pkg/common"
 	"github.com/deislabs/ratify/pkg/executor"
+	"github.com/deislabs/ratify/pkg/homedir"
 	"github.com/deislabs/ratify/pkg/ocispecs"
 	"github.com/deislabs/ratify/pkg/referrerstore"
 	"github.com/deislabs/ratify/pkg/utils"
@@ -39,7 +42,8 @@ import (
 )
 
 const (
-	verifierName = "notaryv2"
+	verifierName    = "notaryv2"
+	defaultCertPath = "ratify-certs"
 )
 
 // NotaryV2VerifierConfig describes the configuration of notation verifier
@@ -73,9 +77,8 @@ func (f *notaryv2VerifierFactory) Create(version string, verifierConfig config.V
 		return nil, fmt.Errorf("failed to parse config for the input: %v", err)
 	}
 
-	if len(conf.VerificationCerts) == 0 {
-		return nil, errors.New("verification certs are missing")
-	}
+	defaultDir := paths.Join(homedir.Get(), ratifyconfig.ConfigFileDir, defaultCertPath)
+	conf.VerificationCerts = append(conf.VerificationCerts, defaultDir)
 
 	artifactTypes := strings.Split(fmt.Sprintf("%s", conf.ArtifactTypes), ",")
 


### PR DESCRIPTION
# Description

This change addresses some paper cuts with running ratify via the CLI and running the docker container by itself. A default notaryv2 certificate directory has been added at `~/.ratify/ratify-certs` so that ratify runs successfully when built from source using the default config.

Fixes #79 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Build, install, and run ratify from the CLI and verify that the default certificate directory is checked
- [x] Build and run the ratify docker container and verify that it serves requests

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?
