### PR TITLE
doc: update quickstart-cli to use oras attach instead of oras push

### DIFF
--- a/docs/quickstart-cli.md
+++ b/docs/quickstart-cli.md
@@ -89,9 +89,8 @@ notation sign --plain-http $IMAGE
 echo '{"version": "0.0.0.0", "artifact": "'${IMAGE}'", "contents": "good"}' > sbom.json
 
 # Push to the registry with the oras cli
-oras push ${REGISTRY}/${REPO} \
+oras attach $IMAGE \
   --artifact-type sbom/example \
-  --subject $IMAGE \
   --plain-http \
   sbom.json:application/json
 ```


### PR DESCRIPTION
Signed-off-by: Binbin Li <libinbin@microsoft.com>

# Description

Oras cli migrated oras push artifact to oras attach command. The quickstart-cli doc is not updated yet. Update the corresponding command in this PR.

Fixes https://github.com/deislabs/ratify/issues/297

## Type of change

Please delete options that are not relevant.

- [x] Doc update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Follow the steps in the doc: https://github.com/deislabs/ratify/blob/main/docs/quickstart-cli.md#verify-a-graph-of-supply-chain-content

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?
