### PR TITLE
Add wrapper for http response with version

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -23,6 +23,8 @@ Example pre-release versions include `v0.1.0-alpha1`, `v0.1.0-beta2`, `v0.1.0-rc
 ## Pre Release Activity
  [Test.bats](test/bats/test.bats) provides limited end to end test coverage, while we are working on improving our coverage, please perform [manual validations](test/ManualValidation.md) to ensure release quality.
 
+ Validate that the format of the data returned for external data calls has not changed. If it has changed update the version in `httpserver/types.go` to reflect a change in the format and document the update.
+
 ## Git Release Flow
 
 This section deals with the practical considerations of versioning in Git, this repo's version control system.  See the semantic versioning specification for the scope of changes allowed for each release type.

--- a/httpserver/handlers.go
+++ b/httpserver/handlers.go
@@ -81,7 +81,7 @@ func (server *Server) verify(ctx context.Context, w http.ResponseWriter, r *http
 			defer mu.Unlock()
 			results = append(results, externaldata.Item{
 				Key:   subject,
-				Value: result,
+				Value: fromVerifyResult(result),
 			})
 		}(utils.SanitizeString(subject))
 	}

--- a/httpserver/types.go
+++ b/httpserver/types.go
@@ -1,0 +1,21 @@
+package httpserver
+
+import (
+	"github.com/deislabs/ratify/pkg/executor/types"
+)
+
+const VerificationResultVersion = "0.1.0"
+
+type VerificationResponse struct {
+	Version         string        `json:"version"`
+	IsSuccess       bool          `json:"isSuccess"`
+	VerifierReports []interface{} `json:"verifierReports,omitempty"`
+}
+
+func fromVerifyResult(res types.VerifyResult) VerificationResponse {
+	return VerificationResponse{
+		Version:         VerificationResultVersion,
+		IsSuccess:       res.IsSuccess,
+		VerifierReports: res.VerifierReports,
+	}
+}

--- a/httpserver/types.go
+++ b/httpserver/types.go
@@ -1,3 +1,18 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package httpserver
 
 import (


### PR DESCRIPTION
# Description

Adds a new type that represents the response for an http request. This type insulates the internal implementation from external consumers and adds a version field so that we can track changes that could break external consumers. For now the format of the response is still not that formally typed, but this gives a starting point.

Fixes #261 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Ran a Ratify request and validated that new version field was part of the response

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [x] Do all new files have appropriate license header?
