### PR TITLE
feat: bump notation-go from v0.8.0-alpha.1 to v0.11.0-alpha.4

### DIFF
--- a/docs/examples/ratify-verify-azure-cmd.md
+++ b/docs/examples/ratify-verify-azure-cmd.md
@@ -4,11 +4,11 @@
 
 ### Notation
 
-Install Notation v0.9.0-alpha.1 with plugin support from [Notation GitHub Release](https://github.com/notaryproject/notation/releases/tag/v0.9.0-alpha.1). 
+Install Notation v0.11.0-alpha.4 with plugin support from [Notation GitHub Release](https://github.com/notaryproject/notation/releases/tag/v0.11.0-alpha.4).
 
 ```bash
 # Download the Notation binary
-curl -Lo notation.tar.gz https://github.com/notaryproject/notation/releases/download/v0.9.0-alpha.1/notation_0.9.0-alpha.1_linux_amd64.tar.gz
+curl -Lo notation.tar.gz https://github.com/notaryproject/notation/releases/download/v0.11.0-alpha.4/notation_0.11.0-alpha.4_linux_amd64.tar.gz
 # Extract it from the binary
 tar xvzf notation.tar.gz
 # Copy the Notation CLI to your bin directory
@@ -17,25 +17,25 @@ mkdir -p ~/bin && cp ./notation ~/bin
 
 ### ORAS
 
-Install ORAS 0.13.0 on a Linux machine. You can refer to the [ORAS installation guide](https://oras.land/cli/) for details.
+Install ORAS 0.15.0 on a Linux machine. You can refer to the [ORAS installation guide](https://oras.land/cli/) for details.
 
 ```bash
 # Download the ORAS binary
-curl -LO https://github.com/oras-project/oras/releases/download/v0.13.0/oras_0.13.0_linux_amd64.tar.gz
+curl -LO https://github.com/oras-project/oras/releases/download/v0.15.0/oras_0.15.0_linux_amd64.tar.gz
 # Create a folder to extract the ORAS binary
 mkdir -p oras-install/
-tar -zxf oras_0.13.0_*.tar.gz -C oras-install/
+tar -zxf oras_0.15.0_*.tar.gz -C oras-install/
 # Copy the Notation CLI to your bin directory
 mv oras-install/oras /usr/local/bin/
 ```
 
 ### Ratify
 
-Install Notation v0.1.4-alpha.1 from [Ratify GitHub Release](https://github.com/deislabs/ratify/releases/tag/v0.1.4-alpha.1). 
+Install Ratify v1.0.0-alpha.2 from [Ratify GitHub Release](https://github.com/deislabs/ratify/releases/tag/v1.0.0-alpha.2).
 
 ```bash
 # Download the Ratify binary
-curl -Lo ratify.tar.gz https://github.com/deislabs/ratify/releases/download/v0.1.4-alpha.1/ratify_0.1.4-alpha.1_Linux_amd64.tar.gz
+curl -Lo ratify.tar.gz https://github.com/deislabs/ratify/releases/download/v1.0.0-alpha.2/ratify_1.0.0-alpha.2_Linux_amd64.tar.gz
 # Extract it from the binary and copy it to the bin directory
 tar xvzf ratify.tar.gz -C ~/bin ratify
 ```
@@ -49,10 +49,11 @@ export REGISTRY=$ACR_NAME.azurecr-test.io
 export REPO=${REGISTRY}/net-monitor
 export IMAGE=${REPO}:v1
 
+
 # Create an ACR
 # Premium to use tokens
-az acr create -n $ACR_NAME -g $(ACR_NAME)-acr --sku Premium
-az configure --default acr=wabbitnetworks
+az acr create -n $ACR_NAME -g $ACR_NAME-acr --sku Premium
+az configure --default acr=$ACR_NAME
 az acr update --anonymous-pull-enabled true
 
 # Using ACR Auth with Tokens
@@ -97,7 +98,7 @@ notation sign $IMAGE
 # List the signatures
 notation list $IMAGE
 ```
-> You can repeat step 3-4 to create multiple signatures to the image.
+> You can repeat step 4-5 to create multiple signatures to the image.
 
 ### Discover & Verify using Ratify
 
@@ -130,7 +131,7 @@ cat <<EOF > ~/.ratify/config.json
                 "name":"notaryv2",
                 "artifactTypes" : "application/vnd.cncf.notary.v2.signature",
                 "verificationCerts": [
-                    "~/.config/notation/certificate/wabbit-networks.io.crt"
+                    "~/.config/notation/localkeys/wabbit-networks.io.crt"
                   ]
             }
         ]
@@ -163,12 +164,10 @@ ratify verify -s $IMAGE_DIGEST_REF
 # Create, Push
 echo '{"version": "0.0.0.0", "artifact": "'${IMAGE}'", "contents": "good"}' > sbom.json
 
-oras push $REPO \
-  --artifact-type 'sbom/example' \
-  --subject $IMAGE \
+oras attach $IMAGE \
+  --artifact-type sbom/example \
   -u $NOTATION_USERNAME -p $NOTATION_PASSWORD \
-  ./sbom.json:application/json
-
+  sbom.json:application/json
 ```
 
 - Sign the SBoM
@@ -177,7 +176,7 @@ oras push $REPO \
 SBOM_DIGEST=$(oras discover -o json \
                 --artifact-type sbom/example \
                 -u $NOTATION_USERNAME -p $NOTATION_PASSWORD \
-                $IMAGE | jq -r ".references[0].digest")
+                $IMAGE | jq -r ".referrers[0].digest")
 
 notation sign $REPO@$SBOM_DIGEST
 ```
@@ -199,9 +198,11 @@ cat <<EOF > ~/.ratify/config.json
     },
     "policy": {
         "version": "1.0.0",
-        "artifactVerificationPolicies": {
-            "application/vnd.cncf.notary.v2.signature": "any",
-            "sbom/example": "all"
+        "plugin": {
+            "name": "configPolicy",
+            "artifactVerificationPolicies": {
+                "application/vnd.cncf.notary.v2.signature": "any"
+            }
         }
     },
     "verifier": {
@@ -211,7 +212,7 @@ cat <<EOF > ~/.ratify/config.json
                 "name":"notaryv2",
                 "artifactTypes" : "application/vnd.cncf.notary.v2.signature",
                 "verificationCerts": [
-                    "~/.config/notation/certificate/wabbit-networks.io.crt"
+                    "~/.config/notation/localkeys/wabbit-networks.io.crt"
                   ]
             },
             {
@@ -219,6 +220,8 @@ cat <<EOF > ~/.ratify/config.json
                 "artifactTypes" : "sbom/example",
                 "nestedReferences": "application/vnd.cncf.notary.v2.signature"
             }
+        ]
+    }
 }
 EOF
 ```

--- a/docs/quickstart-cli.md
+++ b/docs/quickstart-cli.md
@@ -101,7 +101,7 @@ oras attach $IMAGE \
 # Capture the digest of the SBOM, to sign it
 SBOM_DIGEST=$(oras discover -o json \
                 --artifact-type sbom/example \
-                $IMAGE | jq -r ".references[0].digest")
+                $IMAGE | jq -r ".referrers[0].digest")
 
 notation sign --plain-http $REGISTRY/$REPO@$SBOM_DIGEST
 ```
@@ -117,7 +117,8 @@ cat <<EOF > ~/.ratify/config.json
         "version": "1.0.0", 
         "plugins": [ 
             { 
-                "name": "oras"
+                "name": "oras",
+                "useHttp": true,
             }
         ]
     },
@@ -138,7 +139,7 @@ cat <<EOF > ~/.ratify/config.json
                 "name":"notaryv2",
                 "artifactTypes" : "application/vnd.cncf.notary.v2.signature",
                 "verificationCerts": [
-                    "~/.config/notation/certificate/wabbit-networks.io.crt"
+                    "~/.config/notation/localkeys/wabbit-networks.io.crt"
                   ]
             },
             {

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,8 @@ require (
 	github.com/fsnotify/fsnotify v1.5.4
 	github.com/google/go-containerregistry v0.11.0
 	github.com/gorilla/mux v1.8.0
-	github.com/notaryproject/notation-go v0.8.0-alpha.1
+	github.com/notaryproject/notation-core-go v0.1.0-alpha.4
+	github.com/notaryproject/notation-go v0.11.0-alpha.4
 	github.com/open-policy-agent/frameworks/constraint v0.0.0-20220627162905-95c012350402
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.3-0.20220114050600-8b9d41f48198
@@ -77,6 +78,7 @@ require (
 	github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1 // indirect
 	github.com/envoyproxy/protoc-gen-validate v0.6.2 // indirect
 	github.com/fullstorydev/grpcurl v1.8.7 // indirect
+	github.com/fxamacker/cbor/v2 v2.4.0 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-chi/chi v4.1.2+incompatible // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
@@ -172,6 +174,8 @@ require (
 	github.com/transparency-dev/merkle v0.0.1 // indirect
 	github.com/urfave/cli v1.22.7 // indirect
 	github.com/vbatts/tar-split v0.11.2 // indirect
+	github.com/veraison/go-cose v1.0.0-rc.1.0.20220824135457-9d2fab636b83 // indirect
+	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -313,6 +313,8 @@ github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmV
 github.com/fullstorydev/grpcurl v1.8.6/go.mod h1:WhP7fRQdhxz2TkL97u+TCb505sxfH78W1usyoB3tepw=
 github.com/fullstorydev/grpcurl v1.8.7 h1:xJWosq3BQovQ4QrdPO72OrPiWuGgEsxY8ldYsJbPrqI=
 github.com/fullstorydev/grpcurl v1.8.7/go.mod h1:pVtM4qe3CMoLaIzYS8uvTuDj2jVYmXqMUkZeijnXp/E=
+github.com/fxamacker/cbor/v2 v2.4.0 h1:ri0ArlOR+5XunOP8CRUowT0pSJOwhW098ZCUyskZD88=
+github.com/fxamacker/cbor/v2 v2.4.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/fzipp/gocyclo v0.3.1/go.mod h1:DJHO6AUmbdqj2ET4Z9iArSuwWgYDRryYt2wASxc7x3E=
 github.com/getkin/kin-openapi v0.76.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/getsentry/raven-go v0.2.0 h1:no+xWJRb5ZI7eE8TWgIq1jLulQiIoLG0IfYxv5JYMGs=
@@ -832,8 +834,10 @@ github.com/nightlyone/lockfile v1.0.0/go.mod h1:rywoIealpdNse2r832aiD9jRk8ErCatR
 github.com/nishanths/exhaustive v0.2.3/go.mod h1:bhIX678Nx8inLM9PbpvK1yv6oGtoP8BfaIeMzgBNKvc=
 github.com/nishanths/predeclared v0.0.0-20200524104333-86fad755b4d3/go.mod h1:nt3d53pc1VYcphSCIaYAJtnPYnr3Zyn8fMq2wvPGPso=
 github.com/nishanths/predeclared v0.2.1/go.mod h1:HvkGJcA3naj4lOwnFXFDkFxVtSqQMB9sbB1usJ+xjQE=
-github.com/notaryproject/notation-go v0.8.0-alpha.1 h1:YbrmzZiEdK2/XSqwkT0/qvACiJGy7AXSaMbzbQc2RmI=
-github.com/notaryproject/notation-go v0.8.0-alpha.1/go.mod h1:B/JbgikwvLoD9gFeWYhFtxIEozRoFAs9q31mj3vz1i4=
+github.com/notaryproject/notation-core-go v0.1.0-alpha.4 h1:0OhA2PjwT0TAouHOrU4K+8H9YM6E/e4/ocoq+JiHeOw=
+github.com/notaryproject/notation-core-go v0.1.0-alpha.4/go.mod h1:s8DZptmN1rZS0tBLTPt/w+d4o6eAcGWTYYJlXaJhQ4U=
+github.com/notaryproject/notation-go v0.11.0-alpha.4 h1:PNptLtrhW0jyw10hUWU+KNzvzeuBBZmg+/1IUaGYE10=
+github.com/notaryproject/notation-go v0.11.0-alpha.4/go.mod h1:4xYTcW4wfsXkXw3piUA53uSW82RwdXyipSEtiiRVrCw=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
@@ -1090,9 +1094,13 @@ github.com/valyala/quicktemplate v1.7.0/go.mod h1:sqKJnoaOF88V07vkO+9FL8fb9uZg/V
 github.com/valyala/tcplisten v1.0.0/go.mod h1:T0xQ8SeCZGxckz9qRXTfG43PvQ/mcWh7FwZEA7Ioqkc=
 github.com/vbatts/tar-split v0.11.2 h1:Via6XqJr0hceW4wff3QRzD5gAk/tatMw/4ZA7cTlIME=
 github.com/vbatts/tar-split v0.11.2/go.mod h1:vV3ZuO2yWSVsz+pfFzDG/upWH1JhjOiEaWq6kXyQ3VI=
+github.com/veraison/go-cose v1.0.0-rc.1.0.20220824135457-9d2fab636b83 h1:g8vDfnNOPcGzg6mnlBGc0J5t5lAJkaepXqbc9qFRnFs=
+github.com/veraison/go-cose v1.0.0-rc.1.0.20220824135457-9d2fab636b83/go.mod h1:7ziE85vSq4ScFTg6wyoMXjucIGOf4JkFEZi/an96Ct4=
 github.com/viki-org/dnscache v0.0.0-20130720023526-c70c1f23c5d8/go.mod h1:dniwbG03GafCjFohMDmz6Zc6oCuiqgH6tGNyXTkHzXE=
 github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9znI5mJU=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
+github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
+github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.0.2/go.mod h1:1WAq6h33pAW+iRreB34OORO2Nf7qel3VV3fjBj+hCSs=

--- a/pkg/executor/core/executor.go
+++ b/pkg/executor/core/executor.go
@@ -139,7 +139,7 @@ func (ex Executor) verifyReference(ctx context.Context, subjectRef common.Refere
 				verifyResult = vr.VerifierResult{
 					IsSuccess: false,
 					Name:      verifier.Name(),
-					Message:   fmt.Sprintf("an error thrown by the verifier %v", err)}
+					Message:   fmt.Sprintf("an error thrown by the verifier: %v", err)}
 			}
 
 			verifyResult.ArtifactType = referenceDesc.ArtifactType

--- a/pkg/utils/certificateUtils.go
+++ b/pkg/utils/certificateUtils.go
@@ -24,7 +24,7 @@ import (
 	"path/filepath"
 
 	"github.com/deislabs/ratify/pkg/homedir"
-	"github.com/notaryproject/notation-go/crypto/cryptoutil"
+	notationx509 "github.com/notaryproject/notation-core-go/x509"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -90,7 +90,7 @@ func isSymbolicLink(info fs.FileInfo) bool {
 }
 
 func loadCertFile(fileInfo fs.FileInfo, filePath string, certificate []*x509.Certificate, fileMap map[string]bool) ([]*x509.Certificate, error) {
-	cert, certError := cryptoutil.ReadCertificateFile(filePath) // ReadCertificateFile returns empty if file was not a certificate
+	cert, certError := notationx509.ReadCertificateFile(filePath) // ReadCertificateFile returns empty if file was not a certificate
 	if certError != nil {
 		return certificate, certError
 	}


### PR DESCRIPTION
Signed-off-by: Binbin Li <libinbin@microsoft.com>

# Description

1. Bumped up notation-go from v0.8.0-alpha.1 to v0.11.0-alpha.4 and introduced dependency of notation-core-go of v0.1.0-alpha.4.
2. Update the usage of verifier from notation-go. Now the verifier supports both JWS and COSE envelopes now.
3. Update the quickstart-cli.md

Fixes https://github.com/deislabs/ratify/issues/350

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Run steps in quickstart-cli.md and ratify-verify-azure-cmd.md.
<img width="801" alt="image" src="https://user-images.githubusercontent.com/6919333/196640365-98fee93f-0d8b-42ba-ae44-8f3d74a938c1.png">


# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?
