### PR TITLE
fix helm chart to be SemVer latest

### DIFF
--- a/charts/ratify/Chart.yaml
+++ b/charts/ratify/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ratify
 description: A Helm chart for Ratify
-version: 1.0.0
+version: 1.1.1
 appVersion: v1.0.0-alpha.3
 home: https://github.com/deislabs/ratify


### PR DESCRIPTION
Signed-off-by: David Tesar <david.tesar@microsoft.com>

# Description

During the 1.1.0 release, we bumped the chart version to 1.1.0 and then in the next release bumped the chart version down to 1.0.0.  This makes helm deploy an older version of the released version of ratify.

