### PR TITLE
Chart updates to allow cosign and notary verifier to be configured together

### DIFF
--- a/charts/ratify/templates/configmap.yaml
+++ b/charts/ratify/templates/configmap.yaml
@@ -41,10 +41,7 @@ data:
       "policy": {
         "version": "1.0.0",
         "plugin": {
-            "name": "configPolicy",
-            "artifactVerificationPolicies": {
-                "application/vnd.cncf.notary.v2.signature": "all"
-            }
+            "name": "configPolicy"
         }
       },
       "verifier": {
@@ -54,14 +51,14 @@ data:
                 "name":"notaryv2",
                 "artifactTypes" : "application/vnd.cncf.notary.v2.signature",
                 "verificationCerts": [
-                    "/usr/local/ratify-certs"
+                    "/usr/local/ratify-certs/notary"
                   ]
             {{- if .Values.cosign.enabled }}
             },
             {
                 "name": "cosign",
                 "artifactTypes": "org.sigstore.cosign.v1",
-                "key": "/usr/local/ratify-certs/cosign.pub"
+                "key": "/usr/local/ratify-certs/cosign/cosign.pub"
             {{- end }}
             }
           ]

--- a/charts/ratify/templates/deployment.yaml
+++ b/charts/ratify/templates/deployment.yaml
@@ -51,13 +51,18 @@ spec:
           ports:
             - containerPort: 6001
           volumeMounts:
-            - mountPath: "/usr/local/ratify-certs"
-              {{- if .Values.akvCertConfig.enabled }}
+            - mountPath: "/usr/local/ratify-certs/notary"
+            {{- if .Values.akvCertConfig.enabled }}
               name: cert-from-akv
-              {{- else }}
-              name: certs
-              {{- end }}
+            {{- else }}
+              name: notary-certs
+            {{- end }}
               readOnly: true
+            {{- if .Values.cosign.enabled }}
+            - mountPath: "/usr/local/ratify-certs/cosign"
+              name: cosign-certs
+              readOnly: true
+            {{- end }}
             - mountPath: "/usr/local/ratify"
               name: config
               readOnly: true
@@ -88,9 +93,14 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
-        - name: certs
+        - name: notary-certs
           secret:
-            secretName: {{ include "ratify.fullname" . }}-certificate
+            secretName: {{ include "ratify.fullname" . }}-notary-certificate         
+        {{- if .Values.cosign.enabled }}
+        - name: cosign-certs
+          secret:
+            secretName: {{ include "ratify.fullname" . }}-cosign-certificate         
+        {{- end }}
         {{- if $dockerAuthMode }}
         - name: dockerconfig
           secret:

--- a/charts/ratify/templates/secret.yaml
+++ b/charts/ratify/templates/secret.yaml
@@ -1,12 +1,21 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "ratify.fullname" . }}-certificate
+  name: {{ include "ratify.fullname" . }}-notary-certificate
 data:
   ratify-test.crt: {{ .Values.ratifyTestCert | b64enc | quote }}
-  {{- if .Values.cosign.enabled }}
+
+---
+
+{{- if .Values.cosign.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ratify.fullname" . }}-cosign-certificate
+data:
   cosign.pub: {{ .Values.cosign.key | b64enc | quote }}
-  {{- end }}
+
+{{- end }}
  
 ---
 apiVersion: v1

--- a/docs/examples/ratify-on-aws.md
+++ b/docs/examples/ratify-on-aws.md
@@ -126,7 +126,7 @@ but we can look at what will be generated below:
         "plugin": {
             "name": "configPolicy",
             "artifactVerificationPolicies": {
-                "application/vnd.dev.cosign.simplesigning.v1+json": "any"
+                "org.sigstore.cosign.v1": "any"
             }
         }
     },
@@ -135,8 +135,8 @@ but we can look at what will be generated below:
         "plugins": [        
           {
             "name": "cosign",
-            "artifactTypes": "application/vnd.dev.cosign.simplesigning.v1+json",
-            "key": "/usr/local/ratify-certs/cosign.pub"
+            "artifactTypes": "org.sigstore.cosign.v1",
+            "key": "/usr/local/ratify-certs/cosign/cosign.pub"
           }
         ]        
     }

--- a/pkg/referrerstore/oras/cosign.go
+++ b/pkg/referrerstore/oras/cosign.go
@@ -29,7 +29,7 @@ import (
 	oci "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-const CosignArtifactType = "application/vnd.dev.cosign.simplesigning.v1+json"
+const CosignArtifactType = "org.sigstore.cosign.v1"
 const CosignSignatureTagSuffix = ".sig"
 
 func getCosignReferences(subjectReference common.Reference) (*[]ocispecs.ReferenceDescriptor, error) {

--- a/pkg/verifier/notaryv2/notaryv2.go
+++ b/pkg/verifier/notaryv2/notaryv2.go
@@ -35,8 +35,8 @@ import (
 	"github.com/deislabs/ratify/pkg/verifier/config"
 	"github.com/deislabs/ratify/pkg/verifier/factory"
 
-	_ "github.com/notaryproject/notation-core-go/signature/jws"
 	_ "github.com/notaryproject/notation-core-go/signature/cose"
+	_ "github.com/notaryproject/notation-core-go/signature/jws"
 	"github.com/notaryproject/notation-go"
 	"github.com/notaryproject/notation-go/crypto/jwsutil"
 	"github.com/notaryproject/notation-go/signature"
@@ -45,7 +45,7 @@ import (
 
 const (
 	verifierName    = "notaryv2"
-	defaultCertPath = "ratify-certs"
+	defaultCertPath = "ratify-certs/notary"
 )
 
 // NotaryV2VerifierConfig describes the configuration of notation verifier

--- a/test/bats/tests/configmap/invalidconfigmap.yaml
+++ b/test/bats/tests/configmap/invalidconfigmap.yaml
@@ -21,7 +21,7 @@ data:
         "plugin": {
             "name": "configPolicy",
             "artifactVerificationPolicies": {
-                "application/vnd.dev.cosign.simplesigning.v1+json": "any"
+                "org.sigstore.cosign.v1": "any"
             }
         }
       },
@@ -32,7 +32,7 @@ data:
                 "name":"notaryv2",
                 "artifactTypes" : "application/vnd.cncf.notary.v2.signature",
                 "verificationCerts": [
-                    "/usr/local/ratify-certs"
+                    "/usr/local/ratify-certs/notary"
                   ]
             }
           ]


### PR DESCRIPTION
# Description
Noel and Lachie reported an issue where notaryv2.go at VerificationCerts and will validate all of the paths against the notary v2 expectations (x509 certs). Since we pass in /usr/local/ratify-certs - that includes everything, both the ratify-test.crt (good!) as well as the cosign.pub file (not so good!), which is in PEM format.

This PR contains the following update:
- mounts cosign cert and notary cert in separate paths
- removing configmap policy so that when validation will pass if there is only one type of signature available
- fixing inconsistency for cosign artifactType
 
Fixes # (381)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Enabled Notary and Cosign in configuration, run kubectl run with the following image, 

1.Image with only notary signature, deployment was successful when notary signature was valid
2.Image with only cosign signature, deployment successful  
3.Image with both notary and cosign signatures, succeeded when both signatures exist

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?
