### PR TITLE
Fix go concurrency ORAS cache bug

### DIFF
--- a/pkg/referrerstore/oras/oras.go
+++ b/pkg/referrerstore/oras/oras.go
@@ -229,8 +229,9 @@ func (store *orasStore) GetBlobContent(ctx context.Context, subjectReference com
 		}
 
 		// push fetched content to local ORAS cache
+		orasExistsExpectedError := fmt.Errorf("%s: %s: %w", blobDesc.Digest, blobDesc.MediaType, errdef.ErrAlreadyExists)
 		err = store.localCache.Push(ctx, blobDesc, rc)
-		if err != nil && err != errdef.ErrAlreadyExists {
+		if err != nil && err.Error() != orasExistsExpectedError.Error() {
 			return nil, err
 		}
 	}
@@ -266,8 +267,9 @@ func (store *orasStore) GetReferenceManifest(ctx context.Context, subjectReferen
 		}
 
 		// push fetched manifest to local ORAS cache
+		orasExistsExpectedError := fmt.Errorf("%s: %s: %w", referenceDesc.Descriptor.Digest, referenceDesc.Descriptor.MediaType, errdef.ErrAlreadyExists)
 		store.localCache.Push(ctx, referenceDesc.Descriptor, bytes.NewReader(manifestBytes))
-		if err != nil && err != errdef.ErrAlreadyExists {
+		if err != nil && err.Error() != orasExistsExpectedError.Error() {
 			return ocispecs.ReferenceManifest{}, err
 		}
 


### PR DESCRIPTION
Signed-off-by: Akash Singhal <akashsinghal@microsoft.com>

# Description

Fixes ORAS cache concurrency issue. ORAS error didn't match the error we were catching.

Fixes #391 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Unit tests
- [ ] Kubernetes scenario with multiple containers with same image

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?
