### PR TITLE
[Bugfix] Fix ECR and GCR support with Cosign Signatures

### DIFF
--- a/pkg/referrerstore/oras/oras.go
+++ b/pkg/referrerstore/oras/oras.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -174,7 +175,7 @@ func (store *orasStore) ListReferrers(ctx context.Context, subjectReference comm
 	if err := repository.Referrers(ctx, resolvedSubjectDesc.Descriptor, artifactTypeFilter, func(referrers []artifactspec.Descriptor) error {
 		referrerDescriptors = append(referrerDescriptors, referrers...)
 		return nil
-	}); err != nil {
+	}); err != nil && !errors.Is(err, errdef.ErrNotFound) {
 		store.evictAuthCache(subjectReference.Original, err)
 		return referrerstore.ListReferrersResult{}, err
 	}


### PR DESCRIPTION
Signed-off-by: Akash Singhal <akashsinghal@microsoft.com>

# Description

When using ratify with a registry that does not support the referrers API but we want verify Cosign signatures, verification process would fail since referrers API is queried first and a 404 is returned from registry. This fix catches the error and continues.  This follows the original approach we used before we upgraded ORAS to v2. 

This will unblock ECR cosign walk through and using GCR

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] unit tests
- [x] test with GCR signature 

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?
