### PR TITLE
Fix mTLS documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,7 +152,7 @@ Client / Server auth enabled (mTLS)
 *Note: Ratify and Gatekeeper must be installed in the same namespace which allows Ratify access to Gatekeepers CA certificate. The Ratify certificate must have a CN and subjectAltName name which matches the namespace of Gatekeeper and Ratify. For example, if installed to the namespace 'gatekeeper-system', the CN and subjectAltName should be 'ratify.gatekeeper-system'*
 ```
 helm install ratify ./charts/ratify \
-    --namespace gatekeeper-system
+    --namespace gatekeeper-system \
     --set provider.auth="mtls" \
     --set provider.tls.skipVerify=false \
     --set provider.tls.cabundle="$(cat certs/ca.crt | base64 | tr -d '\n\r')" \


### PR DESCRIPTION
Sample command for mTLS documentation is missing a `\` in the command.

Signed-off-by: Akash Singhal <akashsinghal@microsoft.com>

# Description

While testing mTLS, encountered a missing `\` in the sample helm install command.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?
