### PR TITLE
Bugfix: set default path for plugin in Crd code path

### DIFF
--- a/charts/ratify/templates/store.yaml
+++ b/charts/ratify/templates/store.yaml
@@ -6,7 +6,7 @@ spec:
   name: oras
   parameters:
     {{- if .Values.cosign.enabled }}
-    cosign-enabled: true
+    cosignEnabled: true
     {{- end }}
     {{- if .Values.oras.authProviders.azureWorkloadIdentityEnabled }}
     authProvider:

--- a/cmd/ratify/cmd/serve.go
+++ b/cmd/ratify/cmd/serve.go
@@ -67,7 +67,7 @@ func serve(opts serveCmdOptions) error {
 	if opts.enableCrdManager {
 		logrus.Infof("starting crd manager")
 		go manager.StartManager()
-		manager.StartServer(opts.httpServerAddress, opts.certDirectory, opts.caCertFile)
+		manager.StartServer(opts.httpServerAddress, opts.configFilePath, opts.certDirectory, opts.caCertFile)
 
 		return nil
 	}

--- a/config/samples/config_v1alpha1_verifier_cosign.yaml
+++ b/config/samples/config_v1alpha1_verifier_cosign.yaml
@@ -6,4 +6,4 @@ spec:
   name: cosign
   artifactTypes: org.sigstore.cosign.v1
   parameters:
-    key: /usr/local/ratify-certs/cosign.pub
+    key: /usr/local/ratify-certs/cosign/cosign.pub

--- a/pkg/controllers/store_controller.go
+++ b/pkg/controllers/store_controller.go
@@ -99,6 +99,7 @@ func storeAddOrReplace(spec configv1alpha1.StoreSpec, fullname string) error {
 	storeConfigVersion := "1.0.0"
 	if spec.Address == "" {
 		spec.Address = config.GetDefaultPluginPath()
+		storeLogger.Info(fmt.Sprintf("Address was empty, setting to default path %v", spec.Address))
 	}
 	storeReference, err := sf.CreateStoreFromConfig(storeConfig, storeConfigVersion, []string{spec.Address})
 

--- a/pkg/controllers/store_controller.go
+++ b/pkg/controllers/store_controller.go
@@ -27,8 +27,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	configv1alpha1 "github.com/deislabs/ratify/api/v1alpha1"
+	"github.com/deislabs/ratify/config"
 	"github.com/deislabs/ratify/pkg/referrerstore"
-	"github.com/deislabs/ratify/pkg/referrerstore/config"
+	rc "github.com/deislabs/ratify/pkg/referrerstore/config"
 	sf "github.com/deislabs/ratify/pkg/referrerstore/factory"
 	"github.com/deislabs/ratify/pkg/referrerstore/types"
 )
@@ -96,6 +97,9 @@ func storeAddOrReplace(spec configv1alpha1.StoreSpec, fullname string) error {
 	// factory only support a single version of configuration today
 	// when we support multi version store CRD, we will also pass in the corresponding config version so factory can create different version of the object
 	storeConfigVersion := "1.0.0"
+	if spec.Address == "" {
+		spec.Address = config.GetDefaultPluginPath()
+	}
 	storeReference, err := sf.CreateStoreFromConfig(storeConfig, storeConfigVersion, []string{spec.Address})
 
 	if err != nil || storeReference == nil {
@@ -115,14 +119,14 @@ func storeRemove(resourceName string) {
 }
 
 // Returns a store reference from spec
-func specToStoreConfig(storeSpec configv1alpha1.StoreSpec) (config.StorePluginConfig, error) {
+func specToStoreConfig(storeSpec configv1alpha1.StoreSpec) (rc.StorePluginConfig, error) {
 
-	storeConfig := config.StorePluginConfig{}
+	storeConfig := rc.StorePluginConfig{}
 
 	if string(storeSpec.Parameters.Raw) != "" {
 		if err := json.Unmarshal(storeSpec.Parameters.Raw, &storeConfig); err != nil {
 			storeLogger.Error(err, "unable to decode store parameters", "Parameters.Raw", storeSpec.Parameters.Raw)
-			return config.StorePluginConfig{}, err
+			return rc.StorePluginConfig{}, err
 		}
 	}
 	storeConfig[types.Name] = storeSpec.Name

--- a/pkg/controllers/verifier_controller.go
+++ b/pkg/controllers/verifier_controller.go
@@ -102,6 +102,7 @@ func verifierAddOrReplace(spec configv1alpha1.VerifierSpec, objectName string) e
 	verifierConfigVersion := "1.0.0" // TODO: move default values to defaulting webhook in the future #413
 	if spec.Address == "" {
 		spec.Address = config.GetDefaultPluginPath()
+		verifierLogger.Info(fmt.Sprintf("Address was empty, setting to default path %v", spec.Address))
 	}
 	verifierReference, err := vf.CreateVerifierFromConfig(verifierConfig, verifierConfigVersion, []string{spec.Address})
 

--- a/pkg/controllers/verifier_controller.go
+++ b/pkg/controllers/verifier_controller.go
@@ -21,8 +21,9 @@ import (
 	"fmt"
 
 	configv1alpha1 "github.com/deislabs/ratify/api/v1alpha1"
+	"github.com/deislabs/ratify/config"
 	vr "github.com/deislabs/ratify/pkg/verifier"
-	"github.com/deislabs/ratify/pkg/verifier/config"
+	vc "github.com/deislabs/ratify/pkg/verifier/config"
 	vf "github.com/deislabs/ratify/pkg/verifier/factory"
 	"github.com/deislabs/ratify/pkg/verifier/types"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -98,7 +99,10 @@ func verifierAddOrReplace(spec configv1alpha1.VerifierSpec, objectName string) e
 
 	// verifier factory only support a single version of configuration today
 	// when we support multi version verifier CRD, we will also pass in the corresponding config version so factory can create different version of the object
-	verifierConfigVersion := "1.0.0"
+	verifierConfigVersion := "1.0.0" // TODO: move default values to defaulting webhook in the future #413
+	if spec.Address == "" {
+		spec.Address = config.GetDefaultPluginPath()
+	}
 	verifierReference, err := vf.CreateVerifierFromConfig(verifierConfig, verifierConfigVersion, []string{spec.Address})
 
 	if err != nil || verifierReference == nil {
@@ -117,14 +121,14 @@ func verifierRemove(objectName string) {
 }
 
 // returns a verifier reference from spec
-func specToVerifierConfig(verifierSpec configv1alpha1.VerifierSpec) (config.VerifierConfig, error) {
+func specToVerifierConfig(verifierSpec configv1alpha1.VerifierSpec) (vc.VerifierConfig, error) {
 
-	verifierConfig := config.VerifierConfig{}
+	verifierConfig := vc.VerifierConfig{}
 
 	if string(verifierSpec.Parameters.Raw) != "" {
 		if err := json.Unmarshal(verifierSpec.Parameters.Raw, &verifierConfig); err != nil {
 			verifierLogger.Error(err, "unable to decode verifier parameters", "Parameters.Raw", verifierSpec.Parameters.Raw)
-			return config.VerifierConfig{}, err
+			return vc.VerifierConfig{}, err
 		}
 	}
 

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -68,11 +68,10 @@ func init() {
 	//+kubebuilder:scaffold:scheme
 }
 
-func StartServer(httpServerAddress string, certDirectory string, caCertFile string) {
+func StartServer(httpServerAddress string, configFilePath string, certDirectory string, caCertFile string) {
 
 	logrus.Infof("initializing executor with config file at default config path")
 
-	configFilePath := ""
 	cf, err := config.Load(configFilePath)
 
 	configStores, configVerifiers, policy, err := config.CreateFromConfig(cf)

--- a/pkg/verifier/factory/factory.go
+++ b/pkg/verifier/factory/factory.go
@@ -25,6 +25,7 @@ import (
 	"github.com/deislabs/ratify/pkg/verifier/config"
 	"github.com/deislabs/ratify/pkg/verifier/plugin"
 	"github.com/deislabs/ratify/pkg/verifier/types"
+	"github.com/sirupsen/logrus"
 )
 
 var builtInVerifiers = make(map[string]VerifierFactory)
@@ -86,6 +87,7 @@ func CreateVerifiersFromConfig(verifiersConfig config.VerifiersConfig, defaultPl
 
 	if len(verifiersConfig.PluginBinDirs) == 0 {
 		verifiersConfig.PluginBinDirs = []string{defaultPluginPath}
+		logrus.Info("defaultPluginPath set to " + defaultPluginPath)
 	}
 
 	// TODO: do we need to append defaultPlugin path?

--- a/test/bats/test.bats
+++ b/test/bats/test.bats
@@ -19,13 +19,15 @@ SLEEP_TIME=1
     assert_failure
 
     echo "cleaning up"
-    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} kubectl delete pod demo
+    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} kubectl delete pod demo --namespace default
 }
 
 @test "validate crd add, replace and delete" {     
     echo "adding license checker, delete notary verifier and validate deployment fails due to missing notary verifier"
     run kubectl apply -f ./config/samples/config_v1alpha1_verifier_licensechecker.yaml
+    assert_success
     run kubectl delete verifiers.config.ratify.deislabs.io/verifier-notary
+    assert_success
     run kubectl run crdtest --namespace default --image=wabbitnetworks.azurecr.io/test/net-monitor:signed
     assert_failure
 
@@ -37,7 +39,7 @@ SLEEP_TIME=1
     assert_success
 
     echo "cleaning up"
-    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} kubectl delete pod crdtest
+    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} kubectl delete pod crdtest --namespace default
 }
 
 @test "configmap update test" {


### PR DESCRIPTION
# Description
Following issues are fixed in the Crd code path:
- The Crd code path was not setting the default plugin path
- Start Server should take in config path
- remove '-' in Cosign property from oras template

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?
