### PR TITLE
Update signature artifactType for notation rc1

### DIFF
--- a/charts/ratify/templates/configmap.yaml
+++ b/charts/ratify/templates/configmap.yaml
@@ -57,7 +57,7 @@ data:
           "plugins": [
             {
                 "name":"notaryv2",
-                "artifactTypes" : "application/vnd.cncf.notary.v2.signature",
+                "artifactTypes" : "application/vnd.cncf.notary.signature",
                 "verificationCerts": [
                   "/usr/local/ratify-certs/notary/truststore"
                   ],

--- a/charts/ratify/templates/verifier.yaml
+++ b/charts/ratify/templates/verifier.yaml
@@ -4,7 +4,7 @@ metadata:
   name: verifier-notary
 spec:
   name: notaryv2
-  artifactTypes: application/vnd.cncf.notary.v2.signature
+  artifactTypes: application/vnd.cncf.notary.signature
   parameters:
     verificationCerts:
     - /usr/local/ratify-certs/notary/truststore

--- a/config/config.json
+++ b/config/config.json
@@ -15,7 +15,7 @@
         "plugin": {
             "name": "configPolicy",
             "artifactVerificationPolicies": {
-                "application/vnd.cncf.notary.v2.signature": "any"
+                "application/vnd.cncf.notary.signature": "any"
             }
         }
     },
@@ -24,7 +24,7 @@
         "plugins": [
             {
                 "name": "notaryv2",
-                "artifactTypes": "application/vnd.cncf.notary.v2.signature",
+                "artifactTypes": "application/vnd.cncf.notary.signature",
                 "verificationCerts": [
                     "/usr/local/ratify-certs/notary/truststore"
                 ],
@@ -52,7 +52,7 @@
             {
                 "name": "sbom",
                 "artifactTypes": "org.example.sbom.v0",
-                "nestedReferences": "application/vnd.cncf.notary.v2.signature"
+                "nestedReferences": "application/vnd.cncf.notary.signature"
             },
             {
                 "name": "licensechecker",

--- a/config/samples/config_v1alpha1_verifier_notary.yaml
+++ b/config/samples/config_v1alpha1_verifier_notary.yaml
@@ -4,7 +4,7 @@ metadata:
   name: verifier-notary
 spec:
   name: notaryv2
-  artifactTypes: application/vnd.cncf.notary.v2.signature
+  artifactTypes: application/vnd.cncf.notary.signature
   parameters:
     verificationCerts:
     - /usr/local/ratify-certs/notary/truststore

--- a/config/samples/config_v1alpha1_verifier_sbom.yaml
+++ b/config/samples/config_v1alpha1_verifier_sbom.yaml
@@ -6,6 +6,6 @@ spec:
   name: sbom
   artifactTypes: org.example.sbom.v0
   parameters: 
-    nestedReferences: application/vnd.cncf.notary.v2.signature
+    nestedReferences: application/vnd.cncf.notary.signature
  
      

--- a/docs/developer/providers.md
+++ b/docs/developer/providers.md
@@ -24,7 +24,7 @@ The executor is the "glue" that links all Ratify plugin-based components such as
     "plugin": {
         "name": "configPolicy",
         "artifactVerificationPolicies": {
-            "application/vnd.cncf.notary.v2.signature": "any"
+            "application/vnd.cncf.notary.signature": "any"
         }
     }
 },
@@ -87,7 +87,7 @@ The executor is the "glue" that links all Ratify plugin-based components such as
         "plugin": {
             "name": "configPolicy",
             "artifactVerificationPolicies": {
-                "application/vnd.cncf.notary.v2.signature": "any"
+                "application/vnd.cncf.notary.signature": "any"
             }
         }
     },

--- a/docs/examples/ratify-verify-azure-cmd.md
+++ b/docs/examples/ratify-verify-azure-cmd.md
@@ -121,7 +121,7 @@ cat <<EOF > ~/.ratify/config.json
         "plugin": {
             "name": "configPolicy",
             "artifactVerificationPolicies": {
-                "application/vnd.cncf.notary.v2.signature": "any"
+                "application/vnd.cncf.notary.signature": "any"
             }
         }
     },
@@ -130,7 +130,7 @@ cat <<EOF > ~/.ratify/config.json
         "plugins": [
             {
                 "name":"notaryv2",
-                "artifactTypes" : "application/vnd.cncf.notary.v2.signature",
+                "artifactTypes" : "application/vnd.cncf.notary.signature",
                 "verificationCerts": [
                     "~/.config/notation/truststore/x509/ca/wabbit-networks.io/wabbit-networks.io.crt"
                 ],
@@ -215,7 +215,7 @@ cat <<EOF > ~/.ratify/config.json
         "plugin": {
             "name": "configPolicy",
             "artifactVerificationPolicies": {
-                "application/vnd.cncf.notary.v2.signature": "any",
+                "application/vnd.cncf.notary.signature": "any",
                 "sbom/example": "all"
             }
         }
@@ -225,7 +225,7 @@ cat <<EOF > ~/.ratify/config.json
         "plugins": [
             {
                 "name":"notaryv2",
-                "artifactTypes" : "application/vnd.cncf.notary.v2.signature",
+                "artifactTypes" : "application/vnd.cncf.notary.signature",
                 "verificationCerts": [
                     "~/.config/notation/localkeys/wabbit-networks.io.crt"
                   ]
@@ -233,7 +233,7 @@ cat <<EOF > ~/.ratify/config.json
             {
                 "name":"sbom",
                 "artifactTypes" : "sbom/example",
-                "nestedReferences": "application/vnd.cncf.notary.v2.signature"
+                "nestedReferences": "application/vnd.cncf.notary.signature"
             }
         ]
     }

--- a/docs/reference/gatekeeper-policy-authoring.md
+++ b/docs/reference/gatekeeper-policy-authoring.md
@@ -93,7 +93,7 @@ actual values of fields may differ):
             "subject": "localhost:5000/net-monitor:v1"
           },
           {
-            "artifactType": "application/vnd.cncf.notary.v2.signature",
+            "artifactType": "application/vnd.cncf.notary.signature",
             "extensions": {
               "Issuer": "CN=localhost:5000,O=Ratify,L=Seattle,ST=Washington,C=US",
               "SN": "CN=localhost:5000,O=Ratify,L=Seattle,ST=Washington,C=US"

--- a/docs/reference/oras-auth-provider.md
+++ b/docs/reference/oras-auth-provider.md
@@ -26,7 +26,7 @@ The `authProvider` section of configuration file specifies the authentication pr
         "plugin": {
             "name": "configPolicy",
             "artifactVerificationPolicies": {
-                "application/vnd.cncf.notary.v2.signature": "any"
+                "application/vnd.cncf.notary.signature": "any"
             }
         }
     },
@@ -35,7 +35,7 @@ The `authProvider` section of configuration file specifies the authentication pr
         "plugins": [
             {
                 "name":"notaryv2",
-                "artifactTypes" : "application/vnd.cncf.notary.v2.signature",
+                "artifactTypes" : "application/vnd.cncf.notary.signature",
                 "verificationCerts": [
                     "<cert folder>"
                   ]

--- a/pkg/controllers/verifier_controller_test.go
+++ b/pkg/controllers/verifier_controller_test.go
@@ -35,7 +35,7 @@ func TestVerifierAdd_EmptyParameter(t *testing.T) {
 	resetVerifierMap()
 	var testVerifierSpec = configv1alpha1.VerifierSpec{
 		Name:          "notaryv2",
-		ArtifactTypes: "application/vnd.cncf.notary.v2.signature",
+		ArtifactTypes: "application/vnd.cncf.notary.signature",
 	}
 	var resource = "notaryv2"
 

--- a/plugins/verifier/cosign/README.md
+++ b/plugins/verifier/cosign/README.md
@@ -26,7 +26,7 @@ The only configuration that is needed for cosign verifier is the path to the pub
         "plugin": {
             "name": "configPolicy",
             "artifactVerificationPolicies": {
-                "application/vnd.cncf.notary.v2.signature": "any"
+                "application/vnd.cncf.notary.signature": "any"
             }
         }
     },

--- a/test/bats/tests/configmap/invalidconfigmap.yaml
+++ b/test/bats/tests/configmap/invalidconfigmap.yaml
@@ -30,7 +30,7 @@ data:
           "plugins": [
             {
                 "name":"notaryv2",
-                "artifactTypes" : "application/vnd.cncf.notary.v2.signature",
+                "artifactTypes" : "application/vnd.cncf.notary.signature",
                 "verificationCerts": [
                     "/usr/local/ratify-certs/notary"
                   ]


### PR DESCRIPTION
# Description

Notation is updating to align with the signature spec, and will change from using the `application/vnd.cncf.notary.v2.signature` artifactType to using `application/vnd.cncf.notary.signature` in the rc1 release. See also: https://github.com/notaryproject/notation/pull/471

This PR updates the artifactType throughout

**Note: this is a good change for alignment, but an impactful/breaking one.** ArtifactType usage in Ratify needs to match the version of Notation that things were signed with (in this regard, it's very similar to the ORAS Artifact -> OCI Artifact change that also lands in RC1)

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit tests pass
- [ ] TODO: validate with a new set of signed images in k8s after notation releases rc1

# Checklist:

- [x] Does this introduce breaking changes that would require an announcement or bumping the major version?
  - We'll probably want to share the big changes (incl other breaking changes) re: ORAS->OCI artifacts, and the signature artifactType in the community call, release notes, etc.