### PR TITLE
Update devcontainer for latest Ratify

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,15 +16,29 @@ ARG BATS_VERSION="1.8.2"
 RUN curl -Lo bats.tar.gz https://github.com/bats-core/bats-core/archive/v${BATS_VERSION}.tar.gz \
   && tar -zxf bats.tar.gz \
   && bash ./bats-core-${BATS_VERSION}/install.sh /usr/local \
-  && rm -rf ./bats-core-${BATS_VERSION}
+  && rm -rf bats.tar.gz ./bats-core-${BATS_VERSION}
+
+ARG NOTATION_VERSION="1.0.0-rc.1"
+RUN curl -Lo notation.tar.gz https://github.com/notaryproject/notation/releases/download/v${NOTATION_VERSION}/notation_${NOTATION_VERSION}_linux_amd64.tar.gz \
+  && tar -zxf notation.tar.gz \
+  && mv ./notation /usr/local/bin/notation \
+  && rm -rf ./notation.tar.gz
+
+ARG ORAS_VERSION="0.16.0"
+RUN curl -Lo oras.tar.gz https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz \
+  && mkdir -p oras-install \
+  && tar -zxf oras.tar.gz -C oras-install \
+  && mv oras-install/oras /usr/local/bin/ \
+  && rm -rf ./oras-install oras.tar.gz
 
 # [Optional] Uncomment this section to install additional OS packages.
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-  && apt-get -y install --no-install-recommends protobuf-compiler
+  && apt-get -y install --no-install-recommends protobuf-compiler libprotobuf-dev
 
 # [Optional] Uncomment the next lines to use go get to install anything else you need
-# USER vscode
-# RUN go get -x <your-dependency-or-tool>
+USER vscode
+RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28 \
+  && go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2
 
 # [Optional] Uncomment this line to install global node packages.
 # RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,12 +1,25 @@
 # Ratify Dev Container
 
 ## Introduction
+
 This repository is set up for development with [GitHub Codespaces](https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/introduction-to-dev-containers) and VS Code [Dev Containers](https://code.visualstudio.com/docs/remote/containers).
 
-## Included Utilities
-- Docker-in-Docker (with Docker Compose v2 support)
-- protobuf compiler
+## What does this give you
+
+- Default `config.json` that works with the quick start
+- Adds `wabbitnetworks.azurecr.io` cert to the trust store
+- Enables commit signing
+- Allows you to send sample Gatekeeper HTTP requests
+- Provides VS Code debug config
+
+### Utilities
+
+- Azure CLI
+- Bats (bash automated testing system)
+- Docker
 - Helm
 - KinD (Kubernetes in Docker)
-- kubectl
-- Bats (bash automated testing system)
+- Kubectl
+- Notation
+- ORAS
+- Protobuf compiler

--- a/.devcontainer/config.default.json
+++ b/.devcontainer/config.default.json
@@ -1,0 +1,49 @@
+{
+  "executor": {},
+  "store": {
+    "version": "1.0.0",
+    "plugins": [
+      {
+        "name": "oras"
+      }
+    ]
+  },
+  "policy": {
+    "version": "1.0.0",
+    "plugin": {
+      "name": "configPolicy",
+      "artifactVerificationPolicies": {
+        "application/vnd.cncf.notary.signature": "any"
+      }
+    }
+  },
+  "verifier": {
+    "version": "1.0.0",
+    "plugins": [
+      {
+        "name": "notaryv2",
+        "artifactTypes": "application/vnd.cncf.notary.signature",
+        "trustPolicyDoc": {
+          "version": "1.0",
+          "trustPolicies": [
+            {
+              "name": "default",
+              "registryScopes": [
+                "*"
+              ],
+              "signatureVerification": {
+                "level": "strict"
+              },
+              "trustStores": [
+                "ca:certs"
+              ],
+              "trustedIdentities": [
+                "*"
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,14 +29,22 @@
 			"settings": {
 				"go.toolsManagement.checkForUpdates": "local",
 				"go.useLanguageServer": true,
-				"go.gopath": "/go"
+				"go.gopath": "/go",
+				"git.enableCommitSigning": true,
+				"protoc": {
+					"options": [
+						"--proto_path=experimental/ratify/proto/v1"
+					]
+				}
 			},
 			// Add the IDs of extensions you want installed when the container is created.
 			"extensions": [
 				"golang.Go",
 				"ms-azuretools.vscode-docker",
 				"ms-kubernetes-tools.vscode-kubernetes-tools",
-				"DavidAnson.vscode-markdownlint"
+				"DavidAnson.vscode-markdownlint",
+				"humao.rest-client",
+				"zxh404.vscode-proto3"
 			]
 		}
 	},
@@ -47,7 +55,8 @@
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",
 	"features": {
-		"ghcr.io/devcontainers/features/docker-in-docker:1": {},
-		"ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {}
+		"ghcr.io/devcontainers/features/docker-in-docker:latest": {},
+		"ghcr.io/devcontainers/features/kubectl-helm-minikube:latest": {},
+		"ghcr.io/devcontainers/features/azure-cli:latest": {}
 	}
 }

--- a/.devcontainer/gatekeeper.http
+++ b/.devcontainer/gatekeeper.http
@@ -1,0 +1,15 @@
+# these files can be executed in VS Code with the `humao.rest-client` extension
+
+POST http://localhost:6001/ratify/gatekeeper/v1/verify
+Content-Type: application/json
+
+{
+  "apiVersion":"externaldata.gatekeeper.sh/v1alpha1",
+  "kind":"ProviderRequest",
+  "request": {
+    "keys": [
+      "wabbitnetworks.azurecr.io/test/notary-image:signed",
+      "wabbitnetworks.azurecr.io/test/notary-image:unsigned"
+    ]
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -5,3 +5,22 @@ set -euo pipefail
 # set -o xtrace 
 
 go mod tidy
+
+# copy the default dev configuration if one does not exist
+mkdir -p ~/.ratify
+if [ ! -f ~/.ratify/config.json ]; then
+  cp .devcontainer/config.default.json ~/.ratify/config.json
+fi
+
+# create the sample cert so that the default launch task works by default
+mkdir -p ~/.ratify/ratify-certs/notary/truststore/x509/ca/certs
+cp ./test/bats/tests/certificates/wabbit-networks.io.crt ~/.ratify/ratify-certs/notary/truststore/x509/ca/certs/wabbit-networks.io.crt
+
+mkdir -p ~/.ratify/ratify-certs/cosign
+cp ./test/bats/tests/certificates/cosign.pub ~/.ratify/ratify-certs/cosign/cosign.pub
+
+# ensure plugins dir exists
+mkdir -p ~/.ratify/plugins
+
+# symlink .ratify for easy access during development
+ln -snf ~/.ratify .ratify

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,10 @@ bin
 dist/
 local_oras_cache/
 .idea
-.vscode
 __debug_bin
 
 # generated certificate directory
 certs/
+
+# symlink to ~/.ratify folder
+/.ratify

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,40 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Verify",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}/cmd/ratify",
+      "args": [
+        "verify",
+        "-s",
+        "${input:subject}"
+      ],
+    },
+    {
+      "name": "Serve",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}/cmd/ratify",
+      "args": [
+        "serve",
+        "--http",
+        ":6001"
+      ],
+    },
+  ],
+  "inputs": [
+    {
+      "id": "subject",
+      "type": "promptString",
+      "description": "Subject to verify",
+      "default": "wabbitnetworks.azurecr.io/test/notary-image:signed"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

## What this PR does / why we need it:

- Updates the devcontainer to work with the latest toolchain (ORAS `0.16.0`, notation `1.0.0-rc1`, etc)
- Adds VS Code debug config
- Automatically configure Ratify for use with the image used in the quick start (`wabbitnetworks.azurecr.io/test/notary-image:signed`)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Built a new codespace with these changes, ensured that `make` and `F5` debugging work as expected

# Checklist:

- [x] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
  - README in `.devcontainer` updated 