### PR TITLE
Enable verifier plugins to work with store plugins

### DIFF
--- a/pkg/referrerstore/plugin/plugin.go
+++ b/pkg/referrerstore/plugin/plugin.go
@@ -201,3 +201,7 @@ func (sp *StorePlugin) GetConfig() *config.StoreConfig {
 		Store:         sp.rawConfig,
 	}
 }
+
+func (sp *StorePlugin) GetPath() []string {
+	return sp.path
+}

--- a/pkg/verifier/plugin/skel/skel.go
+++ b/pkg/verifier/plugin/skel/skel.go
@@ -87,7 +87,7 @@ func (pc *pcontext) pluginMainCore(name, version string, verifyReference VerifyR
 	// The below is a workaround to be able to use built-in referrer store plugins from within verifier plugins
 	storeConfigs := storeConfig.StoresConfig{
 		Version:       version,
-		PluginBinDirs: nil,
+		PluginBinDirs: input.StoreConfig.PluginBinDirs,
 		Stores:        []storeConfig.StorePluginConfig{input.StoreConfig.Store},
 	}
 	stores, storeErr := factory.CreateStoresFromConfig(storeConfigs, "")


### PR DESCRIPTION
# Description

## What this PR does / why we need it:

- Enables verifier plugins to consume `pluginBinDirs` from STDIN and use them to resolve store plugins
- Adds tests to validate that the path is used
- Adds test coverage to ensure that builtin stores are correctly resolved

Fixes #492

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Added/updated unit tests
- [x] Manually built a store plugin and validated against a verifier plugin

# Checklist:

- [x] Does the affected code have corresponding tests?
