### PR TITLE
Remove executionMode (passthrough mode)

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,6 +1,5 @@
 {
     "executor": {
-        "executionMode": "passthrough"
     },
     "store": {
         "version": "1.0.0",

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ These walk through end-to-end examples of using ratify.
 
 These documents can be found generally useful to understand using or implementing ratify, but do not walk through end-to-end examples.
 
-- [gatekeeper-policy-authoring](reference/gatekeeper-policy-authoring.md) - Authoring gatekeeper policies for use with ratify when it is in passthrough execution mode, including rego references/examples.
+- [gatekeeper-policy-authoring](reference/gatekeeper-policy-authoring.md) - Authoring gatekeeper policies for use with ratify, including rego references/examples.
 - [oras-auth-provider](reference/oras-auth-provider.md) - Explanation of various authentication mechanisms available for use with ratify.
 
 ## developer

--- a/docs/reference/gatekeeper-policy-authoring.md
+++ b/docs/reference/gatekeeper-policy-authoring.md
@@ -1,5 +1,5 @@
 # Gatekeeper Policy Authoring
-Ratify can be deployed using passthrough execution mode behind admission
+Ratify can be deployed behind admission
 controllers such as Gatekeeper. When deployed in this manner Ratify will provide
 the results of all verifiers back to Gatekeeper so that policies can be authored
 in rego.
@@ -136,9 +136,8 @@ interface. This structure includes:
   external data provider or result from some communication issue with the
   external data provider.
 
-When Ratify is configured in passthrough execution mode an array of each
-`VerifyResult` for a subject is included in the `response` field and the overall
-`isSuccess` value will always be true. This allows the policy to be entirely
+An array of each
+`VerifyResult` for a subject is included in the `response` field. This allows the policy to be entirely
 authored in the rego using all the results from the individual verifiers.
 
 Each verifier produces a `VerifierResult` with the following potential fields:
@@ -171,8 +170,8 @@ a [trust policy](https://github.com/notaryproject/notaryproject/blob/main/specs/
 could control the verification level and scopes applied to specified artifact. There 
 could be 2 scenarios needed to pay attention:
 
-1. If Ratify is running in passthrough execution mode, but users forgot to set up scopes 
-for some repositories/artifacts. Then the verification result from notary verifier will be an error saying the policy is missing.
+1. If users forgot to set up scopes
+for some repositories/artifacts, then the verification result from notary verifier will be an error saying the policy is missing.
 2. If users set the verification level in trust policy to any value except `strict`,
 then the notary verification result might be a success even though some underlying
 validation failed. Check the verification level provided in notation for more information: [Signature Verification Level](https://github.com/notaryproject/notaryproject/blob/main/specs/trust-store-trust-policy.md#signature-verification-details)

--- a/httpserver/server_test.go
+++ b/httpserver/server_test.go
@@ -140,7 +140,6 @@ func TestServer_MultipleSubjects_Success(t *testing.T) {
 			ReferrerStores: []referrerstore.ReferrerStore{store},
 			Verifiers:      []verifier.ReferenceVerifier{ver},
 			Config: &exconfig.ExecutorConfig{
-				ExecutionMode:  "",
 				RequestTimeout: nil,
 			},
 		}

--- a/pkg/executor/config/config.go
+++ b/pkg/executor/config/config.go
@@ -15,13 +15,8 @@ limitations under the License.
 
 package config
 
-const (
-	PassthroughExecutionMode = "passthrough"
-)
-
 // ExecutorConfig represents the configuration for the executor
 type ExecutorConfig struct {
-	ExecutionMode  string `json:"executionMode,omitempty"`
 	RequestTimeout *int   `json:"requestTimeout"`
 	// TODO Add cache config
 }

--- a/pkg/executor/core/executor.go
+++ b/pkg/executor/core/executor.go
@@ -128,11 +128,6 @@ func (executor Executor) verifySubjectInternal(ctx context.Context, verifyParame
 	}
 
 	overallVerifySuccess := executor.PolicyEnforcer.OverallVerifyResult(ctx, verifierReports)
-
-	if executor.Config.ExecutionMode == config.PassthroughExecutionMode {
-		overallVerifySuccess = true
-	}
-
 	return types.VerifyResult{IsSuccess: overallVerifySuccess, VerifierReports: verifierReports}, nil
 }
 

--- a/pkg/executor/core/executor_test.go
+++ b/pkg/executor/core/executor_test.go
@@ -82,7 +82,6 @@ func TestVerifySubject_Verify_NoReferrers(t *testing.T) {
 		}},
 		Verifiers: []verifier.ReferenceVerifier{&TestVerifier{}},
 		Config: &exConfig.ExecutorConfig{
-			ExecutionMode:  "",
 			RequestTimeout: nil,
 		},
 	}
@@ -129,7 +128,6 @@ func TestVerifySubject_CanVerify_ExpectedResults(t *testing.T) {
 		ReferrerStores: []referrerstore.ReferrerStore{store},
 		Verifiers:      []verifier.ReferenceVerifier{ver},
 		Config: &exConfig.ExecutorConfig{
-			ExecutionMode:  "default",
 			RequestTimeout: nil,
 		},
 	}
@@ -188,7 +186,6 @@ func TestVerifySubject_VerifyFailures_ExpectedResults(t *testing.T) {
 		ReferrerStores: []referrerstore.ReferrerStore{store},
 		Verifiers:      []verifier.ReferenceVerifier{ver},
 		Config: &exConfig.ExecutorConfig{
-			ExecutionMode:  "",
 			RequestTimeout: nil,
 		},
 	}
@@ -240,7 +237,6 @@ func TestVerifySubject_VerifySuccess_ExpectedResults(t *testing.T) {
 		ReferrerStores: []referrerstore.ReferrerStore{store},
 		Verifiers:      []verifier.ReferenceVerifier{ver},
 		Config: &exConfig.ExecutorConfig{
-			ExecutionMode:  "",
 			RequestTimeout: nil,
 		},
 	}
@@ -300,7 +296,6 @@ func TestVerifySubject_MultipleArtifacts_ExpectedResults(t *testing.T) {
 		ReferrerStores: []referrerstore.ReferrerStore{store},
 		Verifiers:      []verifier.ReferenceVerifier{ver},
 		Config: &exConfig.ExecutorConfig{
-			ExecutionMode:  "",
 			RequestTimeout: nil,
 		},
 	}


### PR DESCRIPTION
# Description

## What this PR does / why we need it:

Removes passthrough mode, per #474
Cleans up docs & references to the feature

In addition to the discussion in the issue, I discovered that execution mode was never set to passthrough in the Helm chart, so I believe this should affect no one, as everyone has been using Gatekeeper + Rego without passthrough mode all along. See https://github.com/deislabs/ratify/blob/main/charts/ratify/templates/configmap.yaml

Fixes #474

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Current tests still pass (there were no tests for executionMode: passthrough)

# Checklist:

- [x] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [x] Does this introduce breaking changes that would require an announcement or bumping the major version?
  - Probably worth a mention in the next release notes + community call. That said, I don't think it affects anyone unless they were manually hacking the Helm chart configmap post-render or post-deployment (or manually deploying everything w/o the chart)
