### PR TITLE
Adds initial docs for creating plugins

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ These documents can be found generally useful to understand using or implementin
 
 - [gatekeeper-policy-authoring](reference/gatekeeper-policy-authoring.md) - Authoring gatekeeper policies for use with ratify when it is in passthrough execution mode, including rego references/examples.
 - [oras-auth-provider](reference/oras-auth-provider.md) - Explanation of various authentication mechanisms available for use with ratify.
+- [creating-plugins](reference/creating-plugins.md) - Details on creating your own plugins for use with ratify.
 
 ## developer
 

--- a/docs/reference/creating-plugins.md
+++ b/docs/reference/creating-plugins.md
@@ -1,0 +1,38 @@
+# Creating Plugins
+
+Ratify supports plugins for [stores](/docs/developer/store.md) and [verifiers](/docs/developer/verifier.md) so that users can add capabilities that aren't included in the core application. This document is a guide on creating your own plugins.
+
+## Overview
+
+At a high level, Ratify will execute plugins as child processes, passing environment variables and JSON over STDIN. A plugin will perform its work and return JSON over STDOUT. There is no restriction for what programming language must be used for a plugin executable. For convenience, plugin skeletons have been created for programs written in Go which handle inputs and provide simple functions for authors to implement.
+
+## Verifier
+
+The easiest way to get started is to use [deislabs/ratify-verifier-plugin](https://github.com/deislabs/ratify-verifier-plugin), which is a template repository that stubs out a working verifier plugin.
+
+## Store
+
+There is a sample store plugin located at [plugins/referrerstore/sample/sample.go](https://github.com/deislabs/ratify/blob/main/plugins/referrerstore/sample/sample.go)
+
+To build the plugin and place it into your plugins dir:
+
+```shell
+cd plugins/referrerstore/sample/
+CGO_ENABLED=0 go build -o ~/.ratify/plugins/sample .
+```
+
+To use the plugin, add the following in your `config.json`:
+
+```json
+"store": {
+  "version": "1.0.0",
+  "plugins": [
+    {
+      "name": "oras"
+    },
+    {
+      "name": "sample"
+    }
+  ]
+},
+```


### PR DESCRIPTION
# Description

## What this PR does / why we need it:

Adds a starting point for docs on creating your own Ratify plugin. Its primary purpose right now is to point to the newly transferred [deislabs/ratify-verifier-plugin](https://github.com/deislabs/ratify-verifier-plugin) repo for verifiers

Fixes #405

## Type of change

Please delete options that are not relevant.

- [x] Documentation-only update
