### PR TITLE
chore: go fmt

### DIFF
--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the config v1alpha1 API group
-//+kubebuilder:object:generate=true
-//+groupName=config.ratify.deislabs.io
+// +kubebuilder:object:generate=true
+// +groupName=config.ratify.deislabs.io
 package v1alpha1
 
 import (

--- a/pkg/referrerstore/oras/authprovider/authprovider.go
+++ b/pkg/referrerstore/oras/authprovider/authprovider.go
@@ -32,12 +32,12 @@ import (
 // This config represents the credentials that should be used
 // when pulling artifacts from specific repositories.
 type AuthConfig struct {
-	Username  string
-	Password  string
+	Username      string
+	Password      string
 	IdentityToken string
-	Email     string
-	Provider  AuthProvider
-	ExpiresOn time.Time
+	Email         string
+	Provider      AuthProvider
+	ExpiresOn     time.Time
 }
 
 type AuthProvider interface {
@@ -126,10 +126,10 @@ func (d *defaultAuthProvider) Provide(ctx context.Context, artifact string) (Aut
 
 	dockerAuthConfig := cfg.AuthConfigs[artifactHostName]
 	authConfig := AuthConfig{
-		Username: dockerAuthConfig.Username,
-		Password: dockerAuthConfig.Password,
+		Username:      dockerAuthConfig.Username,
+		Password:      dockerAuthConfig.Password,
 		IdentityToken: dockerAuthConfig.IdentityToken,
-		Provider: d,
+		Provider:      d,
 	}
 
 	return authConfig, nil

--- a/pkg/referrerstore/oras/authprovider/k8secret_authprovider.go
+++ b/pkg/referrerstore/oras/authprovider/k8secret_authprovider.go
@@ -209,10 +209,10 @@ func (d *k8SecretAuthProvider) resolveCredentialFromSecret(hostName string, secr
 	}
 
 	return AuthConfig{
-		Username:  authConfig.Username,
-		Password:  authConfig.Password,
+		Username:      authConfig.Username,
+		Password:      authConfig.Password,
 		IdentityToken: authConfig.IdentityToken,
-		Provider:  d,
-		ExpiresOn: time.Now().Add(secretTimeout),
+		Provider:      d,
+		ExpiresOn:     time.Now().Add(secretTimeout),
 	}, nil
 }

--- a/pkg/referrerstore/oras/oras.go
+++ b/pkg/referrerstore/oras/oras.go
@@ -338,8 +338,8 @@ func (store *orasStore) createRepository(ctx context.Context, targetRef common.R
 	credentialProvider := func(ctx context.Context, registry string) (auth.Credential, error) {
 		if authConfig.Username != "" || authConfig.Password != "" || authConfig.IdentityToken != "" {
 			return auth.Credential{
-				Username: authConfig.Username,
-				Password: authConfig.Password,
+				Username:     authConfig.Username,
+				Password:     authConfig.Password,
 				RefreshToken: authConfig.IdentityToken,
 			}, nil
 		}

--- a/pkg/verifier/notaryv2/notaryv2_test.go
+++ b/pkg/verifier/notaryv2/notaryv2_test.go
@@ -86,17 +86,17 @@ var (
 	invalidBlobDesc = ocispec.Descriptor{
 		Digest: invalidDigest,
 	}
-	defaultCertDir = paths.Join(homedir.Get(), ratifyconfig.ConfigFileDir, defaultCertPath)
+	defaultCertDir  = paths.Join(homedir.Get(), ratifyconfig.ConfigFileDir, defaultCertPath)
 	testTrustPolicy = map[string]interface{}{
 		"version": "1.0",
 		"trustPolicies": []map[string]interface{}{
 			{
-				"name": "default",
+				"name":           "default",
 				"registryScopes": []string{"*"},
 				"signatureVerification": map[string]string{
 					"level": "strict",
 				},
-				"trustStores": []string{"ca:certs"},
+				"trustStores":       []string{"ca:certs"},
 				"trustedIdentities": []string{"*"},
 			},
 		},
@@ -305,7 +305,7 @@ func TestCreate(t *testing.T) {
 		{
 			name: "created verifier successfully",
 			configMap: map[string]interface{}{
-				"name":        test,
+				"name":           test,
 				"trustPolicyDoc": testTrustPolicy,
 			},
 			expectErr: false,
@@ -335,9 +335,9 @@ func TestVerify(t *testing.T) {
 	}{
 		{
 			name:      "failed getting manifest",
-			ref: invalidRef,
-			refBlob: []byte(""),
-			manifest: ocispecs.ReferenceManifest{},
+			ref:       invalidRef,
+			refBlob:   []byte(""),
+			manifest:  ocispecs.ReferenceManifest{},
 			expect:    failedResult,
 			expectErr: true,
 		},
@@ -352,13 +352,13 @@ func TestVerify(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name: "verified successfully",
-			ref: validRef,
+			name:    "verified successfully",
+			ref:     validRef,
 			refBlob: testRefBlob,
 			manifest: ocispecs.ReferenceManifest{
 				Blobs: []ocispec.Descriptor{validBlobDesc},
 			},
-			expect: verifier.VerifierResult{IsSuccess: true},
+			expect:    verifier.VerifierResult{IsSuccess: true},
 			expectErr: false,
 		},
 	}


### PR DESCRIPTION
# Description

## What this PR does / why we need it:

Adds the results after running `make build`, which includes `go fmt ./...`

Just a small update so that whitespace changes in these files don't add noise during dev
