### PR TITLE
Add configurable logging level

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,6 +28,23 @@
         ":6001"
       ],
     },
+    {
+      // This requires your kubeconfig to be pointed at a cluster with Ratify CRDs installed
+      "name": "Serve w/ CRD manager",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}/cmd/ratify",
+      "env": {
+        "RATIFY_LOG_LEVEL": "debug"
+      },
+      "args": [
+        "serve",
+        "--enable-crd-manager",
+        "--http",
+        ":6001"
+      ],
+    },
   ],
   "inputs": [
     {

--- a/cmd/ratify/cmd/root.go
+++ b/cmd/ratify/cmd/root.go
@@ -16,9 +16,8 @@ limitations under the License.
 package cmd
 
 import (
-	"os"
-
 	"github.com/deislabs/ratify/pkg/common"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -30,7 +29,7 @@ const (
 var Root = New(use, shortDesc)
 
 func New(use, short string) *cobra.Command {
-	common.SetLoggingLevel(os.Getenv("RATIFY_LOG_LEVEL"))
+	common.SetLoggingLevelFromEnv(logrus.StandardLogger())
 	root := &cobra.Command{
 		Use:   use,
 		Short: short,

--- a/cmd/ratify/cmd/root.go
+++ b/cmd/ratify/cmd/root.go
@@ -15,7 +15,12 @@ limitations under the License.
 
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"os"
+
+	"github.com/deislabs/ratify/pkg/common"
+	"github.com/spf13/cobra"
+)
 
 const (
 	use       = "ratify"
@@ -25,6 +30,7 @@ const (
 var Root = New(use, shortDesc)
 
 func New(use, short string) *cobra.Command {
+	common.SetLoggingLevel(os.Getenv("RATIFY_LOG_LEVEL"))
 	root := &cobra.Command{
 		Use:   use,
 		Short: short,

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ These walk through end-to-end examples of using ratify.
 
 These documents can be found generally useful to understand using or implementing ratify, but do not walk through end-to-end examples.
 
+- [usage](reference/usage.md) - Additional information for using the `ratify` executable
 - [gatekeeper-policy-authoring](reference/gatekeeper-policy-authoring.md) - Authoring gatekeeper policies for use with ratify when it is in passthrough execution mode, including rego references/examples.
 - [oras-auth-provider](reference/oras-auth-provider.md) - Explanation of various authentication mechanisms available for use with ratify.
 

--- a/docs/reference/usage.md
+++ b/docs/reference/usage.md
@@ -1,0 +1,15 @@
+# Usage
+
+This page documents useful flags and options supported by Ratify
+
+## Environment variables
+
+- `RATIFY_LOG_LEVEL`: configure the log level. Valid options are
+  - `PANIC`
+  - `FATAL`
+  - `ERROR`
+  - `WARNING`
+  - `INFO` (default)
+  - `DEBUG`
+  - `TRACE`
+- `RATIFY_CONFIG`: change the default Ratify configuration directory. Defaults to `~/.ratify`

--- a/pkg/common/logging.go
+++ b/pkg/common/logging.go
@@ -1,0 +1,39 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+const defaultLevel = logrus.InfoLevel
+
+func SetLoggingLevel(level string) {
+	var logrusLevel logrus.Level
+	if level == "" {
+		logrusLevel = defaultLevel
+	} else {
+		var err error
+		logrusLevel, err = logrus.ParseLevel(level)
+		if err != nil {
+			logrusLevel = defaultLevel
+			logrus.Infof("Invalid log level %s, defaulting to %s", level, defaultLevel)
+			logrus.Infof("Valid log levels are: %v", logrus.AllLevels)
+		}
+	}
+	logrus.Infof("Setting log level to %s", logrusLevel)
+	logrus.SetLevel(logrusLevel)
+}

--- a/pkg/common/logging.go
+++ b/pkg/common/logging.go
@@ -16,12 +16,18 @@ limitations under the License.
 package common
 
 import (
+	"os"
+
 	"github.com/sirupsen/logrus"
 )
 
 const defaultLevel = logrus.InfoLevel
 
-func SetLoggingLevel(level string) {
+func SetLoggingLevelFromEnv(logger *logrus.Logger) {
+	SetLoggingLevel(os.Getenv("RATIFY_LOG_LEVEL"), logger)
+}
+
+func SetLoggingLevel(level string, logger *logrus.Logger) {
 	var logrusLevel logrus.Level
 	if level == "" {
 		logrusLevel = defaultLevel
@@ -30,10 +36,10 @@ func SetLoggingLevel(level string) {
 		logrusLevel, err = logrus.ParseLevel(level)
 		if err != nil {
 			logrusLevel = defaultLevel
-			logrus.Infof("Invalid log level %s, defaulting to %s", level, defaultLevel)
-			logrus.Infof("Valid log levels are: %v", logrus.AllLevels)
+			logger.Infof("Invalid log level %s, defaulting to %s", level, defaultLevel)
+			logger.Infof("Valid log levels are: %v", logrus.AllLevels)
 		}
 	}
-	logrus.Infof("Setting log level to %s", logrusLevel)
-	logrus.SetLevel(logrusLevel)
+	logger.Infof("Setting log level to %s", logrusLevel)
+	logger.SetLevel(logrusLevel)
 }

--- a/pkg/common/logging_test.go
+++ b/pkg/common/logging_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestSetLoggingLevel_DefaultsToInfo_NoEnvVar(t *testing.T) {
+	SetLoggingLevel("")
+
+	if logrus.GetLevel() != logrus.InfoLevel {
+		t.Errorf("Expected log level to be %s, got %s", logrus.InfoLevel, logrus.GetLevel())
+	}
+}
+
+func TestSetLoggingLevel_DefaultsToInfo_BadEnvVar(t *testing.T) {
+	SetLoggingLevel("undefinedlogginglevel")
+
+	if logrus.GetLevel() != logrus.InfoLevel {
+		t.Errorf("Expected log level to be %s, got %s", logrus.InfoLevel, logrus.GetLevel())
+	}
+}
+
+func TestSetLoggingLevel_UsesEnvVar(t *testing.T) {
+	SetLoggingLevel("debug")
+
+	if logrus.GetLevel() != logrus.DebugLevel {
+		t.Errorf("Expected log level to be %s, got %s", logrus.DebugLevel, logrus.GetLevel())
+	}
+}

--- a/pkg/common/logging_test.go
+++ b/pkg/common/logging_test.go
@@ -22,7 +22,8 @@ import (
 )
 
 func TestSetLoggingLevel_DefaultsToInfo_NoEnvVar(t *testing.T) {
-	SetLoggingLevel("")
+	SetLoggingLevel("", logrus.StandardLogger())
+	defer logrus.SetLevel(logrus.InfoLevel)
 
 	if logrus.GetLevel() != logrus.InfoLevel {
 		t.Errorf("Expected log level to be %s, got %s", logrus.InfoLevel, logrus.GetLevel())
@@ -30,7 +31,8 @@ func TestSetLoggingLevel_DefaultsToInfo_NoEnvVar(t *testing.T) {
 }
 
 func TestSetLoggingLevel_DefaultsToInfo_BadEnvVar(t *testing.T) {
-	SetLoggingLevel("undefinedlogginglevel")
+	SetLoggingLevel("undefinedlogginglevel", logrus.StandardLogger())
+	defer logrus.SetLevel(logrus.InfoLevel)
 
 	if logrus.GetLevel() != logrus.InfoLevel {
 		t.Errorf("Expected log level to be %s, got %s", logrus.InfoLevel, logrus.GetLevel())
@@ -38,9 +40,25 @@ func TestSetLoggingLevel_DefaultsToInfo_BadEnvVar(t *testing.T) {
 }
 
 func TestSetLoggingLevel_UsesEnvVar(t *testing.T) {
-	SetLoggingLevel("debug")
+	SetLoggingLevel("debug", logrus.StandardLogger())
+	defer logrus.SetLevel(logrus.InfoLevel)
 
 	if logrus.GetLevel() != logrus.DebugLevel {
 		t.Errorf("Expected log level to be %s, got %s", logrus.DebugLevel, logrus.GetLevel())
+	}
+}
+
+func TestSetLoggingLevel_UpdatesTargetLogger(t *testing.T) {
+	testLogger := logrus.New()
+	SetLoggingLevel("debug", testLogger)
+
+	// ensure the test logger is updated
+	if testLogger.GetLevel() != logrus.DebugLevel {
+		t.Errorf("Expected log level to be %s, got %s", logrus.DebugLevel, testLogger.GetLevel())
+	}
+
+	// ensure the standard logger is not updated
+	if logrus.GetLevel() != logrus.InfoLevel {
+		t.Errorf("Expected log level to be %s, got %s", logrus.InfoLevel, logrus.GetLevel())
 	}
 }

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -55,7 +55,7 @@ import (
 
 var (
 	scheme   = runtime.NewScheme()
-	setupLog = ctrl.Log.WithName("setup")
+	setupLog = logrus.WithField("name", "setup")
 
 	configStores    []referrerstore.ReferrerStore
 	configVerifiers []verifier.ReferenceVerifier


### PR DESCRIPTION
# Description

## What this PR does / why we need it:

As part of plugin development, I'd like to be able to turn on some `DEBUG` logs so I can see what's actually being passed into my plugin, but I don't want to spam users with verbose info at runtime. Ratify currently defaults to the `INFO` log level, and it's not configurable. Other folks have asked for this as well in the issues

* Implements configurable log levels via `RATIFY_LOG_LEVEL`, with the default to the current `INFO` level
* Adds tests for the above
* Adds a new "usage" docs page that documents the `RATIFY_*` environment variables
* Adds debug logging for plugin executables

> Note: I believe it could be valuable to have Cobra-generated markdown docs, and/or add robust documentation for the other env vars that are in use, particularly around auth stores (ex: `AWS_REGION`, `AZURE_TENANT_ID`, etc). Will track in a separate Issue/PR

Fixes #348

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit tests
- [x] Verified that env vars / STDIN data is omitted by default, and is correctly logged with `RATIFY_LOG_LEVEL=DEBUG`

# Checklist:

- [x] Does the affected code have corresponding tests?
- [x] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [x] Do all new files have appropriate license header?
