### PR TITLE
ci: remove markdown file bypass

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - '*.md'
   workflow_dispatch:
 
 permissions: read-all


### PR DESCRIPTION
Signed-off-by: Akash Singhal <akashsinghal@microsoft.com>

# Description

## What this PR does / why we need it:
The github build workflow currently does not get triggered for Pull Requests that only have changes to markdown files. This then blocks the PR from merging since build-pr is a required check. 

This change removes the markdown file bypass.

ORAS CLI repository also does not have a bypass for markdown file. See here: https://github.com/oras-project/oras/blob/a671c16f2dc788699e355dbb2019740ef72f8107/.github/workflows/build.yml#L14

## Which issue(s) this PR fixes *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?
