### PR TITLE
ci: add gatekeeper version matrix

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -55,6 +55,7 @@ jobs:
     strategy:
       matrix:
         KUBERNETES_VERSION: ["1.24.6"]
+        GATEKEEPER_VERSION: ["3.10.0", "3.11.0"]
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -67,10 +68,11 @@ jobs:
           mkdir -p $GITHUB_WORKSPACE/bin
           echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
           make e2e-bootstrap KUBERNETES_VERSION=${{ matrix.KUBERNETES_VERSION }}
+          make generate-certs
       - name: Run e2e
         run: |
-          make e2e-deploy-gatekeeper
-          make e2e-deploy-ratify
+          make e2e-deploy-gatekeeper GATEKEEPER_VERSION=${{ matrix.GATEKEEPER_VERSION }}
+          make e2e-deploy-ratify GATEKEEPER_VERSION=${{ matrix.GATEKEEPER_VERSION }}
           make test-e2e
       - name: Save logs
         if: ${{ always() }}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 BINARY_NAME		= ratify
 INSTALL_DIR		= ~/.ratify
+CERT_DIR        = ${GITHUB_WORKSPACE}/tls/certs
 
 GO_PKG			= github.com/deislabs/ratify
 GIT_COMMIT_HASH = $(shell git rev-parse HEAD)
@@ -13,6 +14,7 @@ LDFLAGS += -X $(GO_PKG)/internal/version.GitTag=$(GIT_TAG)
 
 KIND_VERSION ?= 0.14.0
 KUBERNETES_VERSION ?= 1.25.4
+GATEKEEPER_VERSION ?= 3.11.0
 
 HELM_VERSION ?= 3.9.2
 BATS_TESTS_FILE ?= test/bats/test.bats
@@ -21,6 +23,9 @@ BATS_VERSION ?= 1.7.0
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.24.2
+
+RATIFY_NAMESPACE = ratify-service
+RATIFY_NAME = ratify
 
 all: build test
 
@@ -90,11 +95,11 @@ delete-demo-constraints:
 deploy-gatekeeper:
 	helm repo add gatekeeper https://open-policy-agent.github.io/gatekeeper/charts
 	helm install gatekeeper/gatekeeper  \
+		--version ${GATEKEEPER_VERSION} \
 	    --name-template=gatekeeper \
 	    --namespace gatekeeper-system --create-namespace \
 	    --set enableExternalData=true \
 	    --set controllerManager.dnsPolicy=ClusterFirst,audit.dnsPolicy=ClusterFirst \
-		--version=3.10.0
 
 .PHONY: delete-gatekeeper
 delete-gatekeeper:
@@ -107,6 +112,16 @@ test-e2e:
 .PHONY: test-e2e-cli
 test-e2e-cli:
 	RATIFY_DIR=${INSTALL_DIR} ${GITHUB_WORKSPACE}/bin/bats -t ${BATS_CLI_TESTS_FILE}
+
+.PHONY: generate-certs
+generate-certs:
+	mkdir -p ${CERT_DIR}
+	cd ${CERT_DIR} && openssl genrsa -out ca.key 2048 && \
+	openssl req -new -x509 -days 365 -key ca.key -subj "/O=My Org/CN=External Data Provider CA" -out ca.crt && \
+	openssl genrsa -out server.key 2048 && \
+	openssl req -newkey rsa:2048 -nodes -keyout server.key -subj "/CN=${RATIFY_NAME}.${RATIFY_NAMESPACE}" -out server.csr && \
+	printf "subjectAltName=DNS:${RATIFY_NAME}.${RATIFY_NAMESPACE}" > server.ext && \
+	openssl x509 -req -extfile server.ext -days 365 -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt
 
 install-bats:
 	# Download and install bats
@@ -138,12 +153,12 @@ e2e-helm-install:
 e2e-deploy-gatekeeper: e2e-helm-install
 	./.staging/helm/linux-amd64/helm repo add gatekeeper https://open-policy-agent.github.io/gatekeeper/charts
 	./.staging/helm/linux-amd64/helm install gatekeeper/gatekeeper  \
+	--version ${GATEKEEPER_VERSION} \
     --name-template=gatekeeper \
     --namespace gatekeeper-system --create-namespace \
     --set enableExternalData=true \
     --set validatingWebhookTimeoutSeconds=7 \
     --set auditInterval=0 \
-	--version=3.10.0
 
 e2e-deploy-ratify:
 	docker build --progress=plain --no-cache -f ./httpserver/Dockerfile -t localbuild:test .
@@ -152,8 +167,15 @@ e2e-deploy-ratify:
 	docker build --progress=plain --no-cache --build-arg KUBE_VERSION=${KUBERNETES_VERSION} --build-arg TARGETOS="linux" --build-arg TARGETARCH="amd64" -f crd.Dockerfile -t localbuildcrd:test ./charts/ratify/crds
 	kind load docker-image --name kind localbuildcrd:test
 
-	./.staging/helm/linux-amd64/helm install ratify \
-    ./charts/ratify --atomic --namespace ratify-service --create-namespace --set image.repository=localbuild --set image.crdRepository=localbuildcrd --set image.tag=test
+	./.staging/helm/linux-amd64/helm install ${RATIFY_NAME} \
+    ./charts/ratify --atomic --namespace ${RATIFY_NAMESPACE} --create-namespace \
+	--set image.repository=localbuild \
+	--set image.crdRepository=localbuildcrd \
+	--set image.tag=test \
+	--set gatekeeper.version=${GATEKEEPER_VERSION} \
+	--set-file provider.tls.crt=${CERT_DIR}/server.crt \
+	--set-file provider.tls.key=${CERT_DIR}/server.key \
+	--set provider.tls.cabundle="$(shell cat ${CERT_DIR}/ca.crt | base64 | tr -d '\n')"
 
 ##@ Development
 

--- a/README.md
+++ b/README.md
@@ -52,9 +52,17 @@ NOTE: `validatingWebhookTimeoutSeconds` increased from 3 to 7 so all Ratify oper
 - Deploy ratify and a `demo` constraint on gatekeeper in the default namespace.
 
 ```bash
+export RATIFY_NAMESPACE=default
+export CERT_DIR=path/to/your/certificate/directory # the directory will be created by generate-certs
+
+make generate-certs RATIFY_NAMESPACE=$RATIFY_NAMESPACE CERT_DIR=$CERT_DIR
+
 helm repo add ratify https://deislabs.github.io/ratify
 helm install ratify \
-    ratify/ratify --atomic
+    ratify/ratify --atomic \
+    --set-file provider.tls.crt=${CERT_DIR}/server.crt \
+    --set-file provider.tls.key=${CERT_DIR}/server.key \
+    --set provider.tls.cabundle="$(cat ${CERT_DIR}/ca.crt | base64 | tr -d '\n')"
 
 kubectl apply -f https://deislabs.github.io/ratify/library/default/template.yaml
 kubectl apply -f https://deislabs.github.io/ratify/library/default/samples/constraint.yaml

--- a/charts/ratify/templates/deployment.yaml
+++ b/charts/ratify/templates/deployment.yaml
@@ -44,11 +44,8 @@ spec:
             - "-c"
             - "/usr/local/ratify/config.json"
             - "--enable-crd-manager"
-            {{- if eq .Values.provider.auth "tls" }}
             - --cert-dir=/usr/local/tls
-            {{- end }}
-            {{- if eq .Values.provider.auth "mtls" }}
-            - --cert-dir=/usr/local/tls
+            {{- if (lookup "v1" "Secret" .Release.Namespace "gatekeeper-webhook-server-cert") }}
             - --ca-cert-file=usr/local/tls/client-ca/ca.crt
             {{- end }}
           ports:
@@ -74,15 +71,13 @@ spec:
               name: dockerconfig
               readOnly: true
               {{- end }}
-            {{- if and (.Values.provider.tls.cabundle) (or (eq .Values.provider.auth "tls") (eq .Values.provider.auth "mtls")) }}
             - mountPath: /usr/local/tls
               name: tls
               readOnly: true
-            {{- if eq .Values.provider.auth "mtls" }}
+            {{- if (lookup "v1" "Secret" .Release.Namespace "gatekeeper-webhook-server-cert") }}
             - mountPath: /usr/local/tls/client-ca
               name: client-ca-cert
               readOnly: true
-            {{- end }}
             {{- end }}
           env:
           {{- if .Values.logLevel }}
@@ -139,7 +134,6 @@ spec:
         - name: config
           configMap:
             name: {{ include "ratify.fullname" . }}-configuration
-        {{- if and (.Values.provider.tls.cabundle) (or (eq .Values.provider.auth "tls") (eq .Values.provider.auth "mtls")) }}
         - name: tls
           secret:
             {{- if and .Values.provider.tls.crt .Values.provider.tls.key }}
@@ -152,12 +146,11 @@ spec:
                 path: tls.key
               - key: tls.crt
                 path: tls.crt
-        {{- if eq .Values.provider.auth "mtls" }}
+        {{- if (lookup "v1" "Secret" .Release.Namespace "gatekeeper-webhook-server-cert") }}
         - name: client-ca-cert
           secret:
             secretName: gatekeeper-webhook-server-cert
             items:
               - key: ca.crt
                 path: ca.crt
-        {{- end }}
         {{- end }}

--- a/charts/ratify/templates/provider.yaml
+++ b/charts/ratify/templates/provider.yaml
@@ -1,13 +1,12 @@
+{{- if semverCompare ">= 3.11.0" .Values.gatekeeper.version }}
+apiVersion: externaldata.gatekeeper.sh/v1beta1
+{{- else }}
 apiVersion: externaldata.gatekeeper.sh/v1alpha1
+{{- end }}
 kind: Provider
 metadata:
   name: ratify-provider
 spec:
-  url: {{ if .Values.provider.auth }}https{{ else }}http{{ end }}://{{ include "ratify.fullname" .}}.{{ .Release.Namespace }}:6001/ratify/gatekeeper/v1/verify
+  url: https://{{ include "ratify.fullname" .}}.{{ .Release.Namespace }}:6001/ratify/gatekeeper/v1/verify
   timeout: 7
-  {{- if .Values.provider.tls.skipVerify }} # allow gatekeeper with version < 3.9.x
-  insecureTLSSkipVerify: true # enable this if the provider uses HTTP so that Gatekeeper can skip TLS verification.
-  {{- end }}
-  {{- if .Values.provider.auth }}
-  caBundle: {{ required "You must provide .Values.provider.tls.cabundle when .Values.provider.auth is set" .Values.provider.tls.cabundle }}
-  {{- end }}
+  caBundle: {{ required "You must provide .Values.provider.tls.cabundle" .Values.provider.tls.cabundle }}

--- a/charts/ratify/values.yaml
+++ b/charts/ratify/values.yaml
@@ -45,6 +45,8 @@ resources:
 serviceAccount:
   create: true
   name: ratify-admin
+gatekeeper:
+  version: "3.11.0"
 
 # Can be used to authenticate to:
 # ACR -> oras.authProviders.azureWorkloadIdentityEnabled
@@ -71,12 +73,10 @@ oras:
     awsEcrBasicEnabled: false
 
 provider:
-  auth: ""                  # tls, mtls
   tls:
-    skipVerify: true        # skip TLS verification
-    crt: ""                 # crt used by ratify (httpserver)
-    key: ""                 # key used by ratify (httpserver)
-    cabundle: ""            # base64 encoded CA bundle used for the 'caBundle' property for the ratify provider within gatekeeper
+    crt: # crt used by ratify (httpserver), please provide your own crt
+    key: # key used by ratify (httpserver), please provide your own key
+    cabundle: # base64 encoded CA bundle used for the 'caBundle' property for the ratify provider within gatekeeper
 
 podAnnotations: {}
 podLabels: {}

--- a/httpserver/server.go
+++ b/httpserver/server.go
@@ -104,7 +104,11 @@ func (server *Server) Run() error {
 			svr.TLSConfig = config
 			logrus.Info(fmt.Sprintf("%s: [%s:%s] ", "loaded client CA certificate for mTLS", "CaFIle", server.CaCertFile))
 		}
-		return svr.ServeTLS(lsnr, certFile, keyFile)
+		if err := svr.ServeTLS(lsnr, certFile, keyFile); err != nil {
+			logrus.Errorf("failed to start server: %v", err)
+			return err
+		}
+		return nil
 	} else {
 		logrus.Info("starting server without TLS")
 		return svr.Serve(lsnr)


### PR DESCRIPTION
# Description

## What this PR does / why we need it:
As Gatekeeper v3.11.0 comes out, Ratify needs to bump external data to v1beta1 and use TLS/mTLS. To be consistent with GK, Ratify will support the latest 2 versions, which are 3.10.0 and 3.11.0 for now.

This PR just add a make target to generate TLS certs/keys. There will be a following PR to add a helm hook to automate the generation.

## Which issue(s) this PR fixes *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
We have a issue: https://github.com/deislabs/ratify/issues/529 to track the upgrade.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

e2e tests.
Tested manually in gatekeeper-system namespace, which picked up the cert and set mTLS successfully.

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?
