### PR TITLE
feat: move nested reference logic to executor (keep config w/ verifiers)

### DIFF
--- a/pkg/executor/core/executor.go
+++ b/pkg/executor/core/executor.go
@@ -165,11 +165,9 @@ func (ex Executor) addNestedVerifierResult(ctx context.Context, referenceDesc oc
 		ReferenceTypes: []string{"*"},
 	}
 
-	// error is never returned from ex.VerifySubject, if an err occurs, the result contains the error message
 	nestedVerifyResult, err := ex.VerifySubject(ctx, verifyParameters)
-
 	if err != nil {
-		logrus.Errorf("Error verifying subject %s@%s: %v", subjectRef.Path, referenceDesc.Digest, err)
+		nestedVerifyResult = ex.PolicyEnforcer.ErrorToVerifyResult(ctx, verifyParameters.Subject, err)
 	}
 
 	for _, report := range nestedVerifyResult.VerifierReports {

--- a/pkg/executor/core/executor.go
+++ b/pkg/executor/core/executor.go
@@ -136,13 +136,17 @@ func (ex Executor) verifyReference(ctx context.Context, subjectRef common.Refere
 
 	for _, verifier := range ex.Verifiers {
 		if verifier.CanVerify(ctx, referenceDesc) {
-			verifyResult, err := verifier.Verify(ctx, subjectRef, referenceDesc, referrerStore, ex)
+			verifyResult, err := verifier.Verify(ctx, subjectRef, referenceDesc, referrerStore)
 			verifyResult.Subject = subjectRef.String()
 			if err != nil {
 				verifyResult = vr.VerifierResult{
 					IsSuccess: false,
 					Name:      verifier.Name(),
 					Message:   fmt.Sprintf("an error thrown by the verifier: %v", err)}
+			}
+
+			if len(verifier.GetNestedReferences()) > 0 {
+				ex.addNestedVerifierResult(ctx, referenceDesc, subjectRef, &verifyResult)
 			}
 
 			verifyResult.ArtifactType = referenceDesc.ArtifactType
@@ -153,4 +157,28 @@ func (ex Executor) verifyReference(ctx context.Context, subjectRef common.Refere
 	}
 
 	return types.VerifyResult{IsSuccess: isSuccess, VerifierReports: verifyResults}
+}
+
+func (ex Executor) addNestedVerifierResult(ctx context.Context, referenceDesc ocispecs.ReferenceDescriptor, subjectRef common.Reference, verifyResult *vr.VerifierResult) {
+	verifyParameters := e.VerifyParameters{
+		Subject:        fmt.Sprintf("%s@%s", subjectRef.Path, referenceDesc.Digest),
+		ReferenceTypes: []string{"*"},
+	}
+
+	// error is never returned from ex.VerifySubject, if an err occurs, the result contains the error message
+	nestedVerifyResult, err := ex.VerifySubject(ctx, verifyParameters)
+
+	if err != nil {
+		logrus.Errorf("Error verifying subject %s@%s: %v", subjectRef.Path, referenceDesc.Digest, err)
+	}
+
+	for _, report := range nestedVerifyResult.VerifierReports {
+		if result, ok := report.(vr.VerifierResult); ok {
+			verifyResult.NestedResults = append(verifyResult.NestedResults, result)
+			if !nestedVerifyResult.IsSuccess {
+				verifyResult.IsSuccess = false
+				verifyResult.Message = "nested verification failed"
+			}
+		}
+	}
 }

--- a/pkg/executor/core/executor_test.go
+++ b/pkg/executor/core/executor_test.go
@@ -398,7 +398,6 @@ func TestVerifySubject_NestedReferences_Expected(t *testing.T) {
 			}
 		}
 	}
-
 }
 
 // TestVerifySubject__NoNestedReferences_Expected tests verifier config can specify no nested references
@@ -468,5 +467,4 @@ func TestVerifySubject_NoNestedReferences_Expected(t *testing.T) {
 			t.Fatalf("expected reports to have zero nested results")
 		}
 	}
-
 }

--- a/pkg/executor/core/executor_test.go
+++ b/pkg/executor/core/executor_test.go
@@ -322,12 +322,13 @@ func TestVerifySubject_MultipleArtifacts_ExpectedResults(t *testing.T) {
 	}
 }
 
-// TestVerifySubject_NestedReferences_Expected tests verifier config can specify nested results
+// TestVerifySubject_NestedReferences_Expected tests verifier config can specify nested references
 func TestVerifySubject_NestedReferences_Expected(t *testing.T) {
 	configPolicy := config.PolicyEnforcer{
 		ArtifactTypePolicies: map[string]types.ArtifactTypeVerifyPolicy{
 			"default": "all",
 		}}
+
 	store := mocks.CreateNewTestStoreForNestedSbom()
 
 	// sbom verifier WITH nested references in config
@@ -370,14 +371,13 @@ func TestVerifySubject_NestedReferences_Expected(t *testing.T) {
 	}
 
 	if !result.IsSuccess {
-		t.Fatal("verification expected to fail")
+		t.Fatal("verification expected to succeed")
 	}
 
 	if len(result.VerifierReports) != 2 {
 		t.Fatalf("verification expected to return two reports but actual count %d", len(result.VerifierReports))
 	}
 
-	// check that sbom has a nested result
 	for _, report := range result.VerifierReports {
 		castedReport := report.(verifier.VerifierResult)
 
@@ -385,7 +385,7 @@ func TestVerifySubject_NestedReferences_Expected(t *testing.T) {
 		if castedReport.ArtifactType == mocks.SbomArtifactType {
 			// check sbom has one nested results
 			if len(castedReport.NestedResults) != 1 {
-				t.Fatalf("Expected sbom to have a nested result")
+				t.Fatalf("Expected sbom report to have 1 nested result")
 			}
 			// check sbom nested result is successful
 			if !castedReport.NestedResults[0].IsSuccess {
@@ -394,14 +394,14 @@ func TestVerifySubject_NestedReferences_Expected(t *testing.T) {
 		} else {
 			// check non-sbom reports have zero nested results
 			if len(castedReport.NestedResults) != 0 {
-				t.Fatalf("Expected sbom to have a nested result")
+				t.Fatalf("Expected non-sboms reports to have zero nested results")
 			}
 		}
 	}
 
 }
 
-// TestVerifySubject__NoNestedReferences_Expected tests verifier config can specify no nested results
+// TestVerifySubject__NoNestedReferences_Expected tests verifier config can specify no nested references
 func TestVerifySubject_NoNestedReferences_Expected(t *testing.T) {
 	configPolicy := config.PolicyEnforcer{
 		ArtifactTypePolicies: map[string]types.ArtifactTypeVerifyPolicy{
@@ -448,25 +448,24 @@ func TestVerifySubject_NoNestedReferences_Expected(t *testing.T) {
 	}
 
 	if !result.IsSuccess {
-		t.Fatal("verification expected to fail")
+		t.Fatal("verification expected to succeed")
 	}
 
 	if len(result.VerifierReports) != 2 {
 		t.Fatalf("verification expected to return two reports but actual count %d", len(result.VerifierReports))
 	}
 
-	// check that reports have zero nested results
-	// check each result for:
+	// check each report for: success, zero nested results
 	for _, report := range result.VerifierReports {
 		castedReport := report.(verifier.VerifierResult)
 
-		// check success
+		// check for success
 		if !castedReport.IsSuccess {
 			t.Fatal("verification expected to succeed")
 		}
-		// no nested results
+		// check there are no nested results
 		if len(castedReport.NestedResults) != 0 {
-			t.Fatalf("no nested results")
+			t.Fatalf("expected reports to have zero nested results")
 		}
 	}
 

--- a/pkg/executor/core/testtypes.go
+++ b/pkg/executor/core/testtypes.go
@@ -19,15 +19,15 @@ import (
 	"context"
 
 	"github.com/deislabs/ratify/pkg/common"
-	"github.com/deislabs/ratify/pkg/executor"
 	"github.com/deislabs/ratify/pkg/ocispecs"
 	"github.com/deislabs/ratify/pkg/referrerstore"
 	"github.com/deislabs/ratify/pkg/verifier"
 )
 
 type TestVerifier struct {
-	CanVerifyFunc func(artifactType string) bool
-	VerifyResult  func(artifactType string) bool
+	CanVerifyFunc    func(artifactType string) bool
+	VerifyResult     func(artifactType string) bool
+	nestedReferences []string
 }
 
 func (s *TestVerifier) Name() string {
@@ -41,9 +41,12 @@ func (s *TestVerifier) CanVerify(ctx context.Context, referenceDescriptor ocispe
 func (s *TestVerifier) Verify(ctx context.Context,
 	subjectReference common.Reference,
 	referenceDescriptor ocispecs.ReferenceDescriptor,
-	referrerStore referrerstore.ReferrerStore,
-	executor executor.Executor) (verifier.VerifierResult, error) {
+	referrerStore referrerstore.ReferrerStore) (verifier.VerifierResult, error) {
 	return verifier.VerifierResult{
 		IsSuccess: s.VerifyResult(referenceDescriptor.ArtifactType),
 	}, nil
+}
+
+func (s *TestVerifier) GetNestedReferences() []string {
+	return s.nestedReferences
 }

--- a/pkg/referrerstore/mocks/memory_store.go
+++ b/pkg/referrerstore/mocks/memory_store.go
@@ -1,0 +1,141 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mocks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/deislabs/ratify/pkg/common"
+	"github.com/deislabs/ratify/pkg/ocispecs"
+	"github.com/deislabs/ratify/pkg/referrerstore"
+	"github.com/deislabs/ratify/pkg/referrerstore/config"
+	"github.com/opencontainers/go-digest"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+type memoryTestStore struct {
+	Subjects  map[digest.Digest]*ocispecs.SubjectDescriptor
+	Referrers map[digest.Digest][]ocispecs.ReferenceDescriptor
+}
+
+func (store *memoryTestStore) ListReferrers(ctx context.Context, subjectReference common.Reference, artifactTypes []string, nextToken string, subjectDesc *ocispecs.SubjectDescriptor) (referrerstore.ListReferrersResult, error) {
+	// assume subjectDesc is given and good
+
+	if item, ok := store.Referrers[subjectDesc.Digest]; ok {
+		return referrerstore.ListReferrersResult{
+			Referrers: item,
+			NextToken: "",
+		}, nil
+	}
+
+	return referrerstore.ListReferrersResult{}, nil
+}
+
+func (s *memoryTestStore) Name() string {
+	return "memoryTestStore"
+}
+
+func (s *memoryTestStore) GetBlobContent(ctx context.Context, subjectReference common.Reference, digest digest.Digest) ([]byte, error) {
+	return nil, nil
+}
+
+func (s *memoryTestStore) GetReferenceManifest(ctx context.Context, subjectReference common.Reference, referenceDesc ocispecs.ReferenceDescriptor) (ocispecs.ReferenceManifest, error) {
+	return ocispecs.ReferenceManifest{}, nil
+}
+
+func (s *memoryTestStore) GetConfig() *config.StoreConfig {
+	return &config.StoreConfig{}
+}
+
+func (store *memoryTestStore) GetSubjectDescriptor(ctx context.Context, subjectReference common.Reference) (*ocispecs.SubjectDescriptor, error) {
+
+	if item, ok := store.Subjects[subjectReference.Digest]; ok {
+		return item, nil
+	}
+
+	return nil, fmt.Errorf("subject not found for %s", subjectReference.Digest)
+}
+
+func createEmptyMemoryTestStore() *memoryTestStore {
+	return &memoryTestStore{Subjects: make(map[digest.Digest]*ocispecs.SubjectDescriptor), Referrers: make(map[digest.Digest][]ocispecs.ReferenceDescriptor)}
+}
+
+func CreateNewTestStoreForNestedSbom() referrerstore.ReferrerStore {
+	store := createEmptyMemoryTestStore()
+
+	addSignedImageWithSignedSbomToStore(store)
+
+	return store
+}
+
+const (
+	TestSubjectWithDigest = "localhost:5000/net-monitor:v1@sha256:b556844e6e59451caf4429eb1de50aa7c50e4b1cc985f9f5893affe4b73f9935"
+	SbomArtifactType      = "org.example.sbom.v0"
+	SignatureArtifactType = "application/vnd.cncf.notary.signature"
+	dockerMediaType       = "application/vnd.docker.distribution.manifest.v2+json"
+	artifactMediaType     = "application/vnd.oci.artifact.manifest.v1+json"
+)
+
+func addSignedImageWithSignedSbomToStore(store *memoryTestStore) {
+	imageDigest := digest.NewDigestFromEncoded("sha256", "b556844e6e59451caf4429eb1de50aa7c50e4b1cc985f9f5893affe4b73f9935")
+	sbomDigest := digest.NewDigestFromEncoded("sha256", "9393779549fca5758811d7cf0444ddb1b254cb24b44fe1cf80fac6fd3199817f")
+	sbomSignatureDigest := digest.NewDigestFromEncoded("sha256", "ace31a6d260ee372caaed757b3411b634b2cecc379c31fda979dba4470699227")
+	imageSignatureDigest := digest.NewDigestFromEncoded("sha256", "1e42660cb1eec8d21b66c459796717da47e1b540542d6ef26c9f28ad74da9fa5")
+
+	// Add image subject
+	store.Subjects[imageDigest] = &ocispecs.SubjectDescriptor{
+		Descriptor: v1.Descriptor{
+			Digest:    imageDigest,
+			MediaType: dockerMediaType,
+		},
+	}
+
+	// Add image refeerrers
+	store.Referrers[imageDigest] = []ocispecs.ReferenceDescriptor{
+		{
+			Descriptor: v1.Descriptor{
+				MediaType: artifactMediaType,
+				Digest:    sbomDigest,
+			},
+			ArtifactType: SbomArtifactType,
+		},
+		{
+			Descriptor: v1.Descriptor{
+				MediaType: artifactMediaType,
+				Digest:    imageSignatureDigest,
+			},
+			ArtifactType: SignatureArtifactType,
+		},
+	}
+
+	// Add sbom subject
+	store.Subjects[sbomDigest] = &ocispecs.SubjectDescriptor{
+		Descriptor: v1.Descriptor{
+			Digest:    sbomDigest,
+			MediaType: artifactMediaType,
+		},
+	}
+
+	// Add sbom refeerrers
+	store.Referrers[sbomDigest] = []ocispecs.ReferenceDescriptor{
+		{
+			Descriptor: v1.Descriptor{
+				MediaType: artifactMediaType,
+				Digest:    sbomSignatureDigest,
+			},
+			ArtifactType: SignatureArtifactType,
+		},
+	}
+}

--- a/pkg/referrerstore/mocks/memory_store.go
+++ b/pkg/referrerstore/mocks/memory_store.go
@@ -60,7 +60,6 @@ func (s *memoryTestStore) GetConfig() *config.StoreConfig {
 }
 
 func (store *memoryTestStore) GetSubjectDescriptor(ctx context.Context, subjectReference common.Reference) (*ocispecs.SubjectDescriptor, error) {
-
 	if item, ok := store.Subjects[subjectReference.Digest]; ok {
 		return item, nil
 	}

--- a/pkg/verifier/api.go
+++ b/pkg/verifier/api.go
@@ -19,7 +19,6 @@ import (
 	"context"
 
 	"github.com/deislabs/ratify/pkg/common"
-	"github.com/deislabs/ratify/pkg/executor"
 	"github.com/deislabs/ratify/pkg/ocispecs"
 	"github.com/deislabs/ratify/pkg/referrerstore"
 )
@@ -47,6 +46,7 @@ type ReferenceVerifier interface {
 	Verify(ctx context.Context,
 		subjectReference common.Reference,
 		referenceDescriptor ocispecs.ReferenceDescriptor,
-		referrerStore referrerstore.ReferrerStore,
-		executor executor.Executor) (VerifierResult, error)
+		referrerStore referrerstore.ReferrerStore) (VerifierResult, error)
+
+	GetNestedReferences() []string
 }

--- a/pkg/verifier/factory/factory_test.go
+++ b/pkg/verifier/factory/factory_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/deislabs/ratify/pkg/common"
-	"github.com/deislabs/ratify/pkg/executor"
 	"github.com/deislabs/ratify/pkg/ocispecs"
 	"github.com/deislabs/ratify/pkg/referrerstore"
 
@@ -43,9 +42,12 @@ func (s *TestVerifier) CanVerify(ctx context.Context, referenceDescriptor ocispe
 func (s *TestVerifier) Verify(ctx context.Context,
 	subjectReference common.Reference,
 	referenceDescriptor ocispecs.ReferenceDescriptor,
-	referrerStore referrerstore.ReferrerStore,
-	executor executor.Executor) (verifier.VerifierResult, error) {
+	referrerStore referrerstore.ReferrerStore) (verifier.VerifierResult, error) {
 	return verifier.VerifierResult{IsSuccess: false}, nil
+}
+
+func (s *TestVerifier) GetNestedReferences() []string {
+	return []string{}
 }
 
 func (f *TestVerifierFactory) Create(version string, verifierConfig config.VerifierConfig) (verifier.ReferenceVerifier, error) {

--- a/pkg/verifier/notaryv2/notaryv2.go
+++ b/pkg/verifier/notaryv2/notaryv2.go
@@ -124,7 +124,6 @@ func (v *notaryV2Verifier) Verify(ctx context.Context,
 	subjectReference common.Reference,
 	referenceDescriptor ocispecs.ReferenceDescriptor,
 	store referrerstore.ReferrerStore) (verifier.VerifierResult, error) {
-
 	extensions := make(map[string]string)
 
 	subjectDesc, err := store.GetSubjectDescriptor(ctx, subjectReference)

--- a/pkg/verifier/notaryv2/notaryv2.go
+++ b/pkg/verifier/notaryv2/notaryv2.go
@@ -25,7 +25,6 @@ import (
 
 	ratifyconfig "github.com/deislabs/ratify/config"
 	"github.com/deislabs/ratify/pkg/common"
-	"github.com/deislabs/ratify/pkg/executor"
 	"github.com/deislabs/ratify/pkg/homedir"
 	"github.com/deislabs/ratify/pkg/ocispecs"
 	"github.com/deislabs/ratify/pkg/referrerstore"
@@ -124,8 +123,8 @@ func (v *notaryV2Verifier) CanVerify(ctx context.Context, referenceDescriptor oc
 func (v *notaryV2Verifier) Verify(ctx context.Context,
 	subjectReference common.Reference,
 	referenceDescriptor ocispecs.ReferenceDescriptor,
-	store referrerstore.ReferrerStore,
-	executor executor.Executor) (verifier.VerifierResult, error) {
+	store referrerstore.ReferrerStore) (verifier.VerifierResult, error) {
+
 	extensions := make(map[string]string)
 
 	subjectDesc, err := store.GetSubjectDescriptor(ctx, subjectReference)
@@ -199,4 +198,9 @@ func parseVerifierConfig(verifierConfig config.VerifierConfig) (*NotaryV2Verifie
 	conf.VerificationCerts = append(conf.VerificationCerts, defaultCertsDir)
 
 	return conf, nil
+}
+
+// signatures should not have nested references
+func (v *notaryV2Verifier) GetNestedReferences() []string {
+	return []string{}
 }

--- a/pkg/verifier/notaryv2/notaryv2_test.go
+++ b/pkg/verifier/notaryv2/notaryv2_test.go
@@ -361,7 +361,7 @@ func TestVerify(t *testing.T) {
 				manifest: tt.manifest,
 			}
 
-			result, err := v.Verify(context.Background(), tt.ref, ocispecs.ReferenceDescriptor{}, store, testExecutor)
+			result, err := v.Verify(context.Background(), tt.ref, ocispecs.ReferenceDescriptor{}, store)
 
 			if (err != nil) != tt.expectErr {
 				t.Fatalf("error = %v, expectErr = %v", err, tt.expectErr)

--- a/pkg/verifier/notaryv2/notaryv2_test.go
+++ b/pkg/verifier/notaryv2/notaryv2_test.go
@@ -8,12 +8,9 @@ import (
 	paths "path/filepath"
 	"reflect"
 	"testing"
-	"time"
 
 	ratifyconfig "github.com/deislabs/ratify/config"
 	"github.com/deislabs/ratify/pkg/common"
-	e "github.com/deislabs/ratify/pkg/executor"
-	"github.com/deislabs/ratify/pkg/executor/types"
 	"github.com/deislabs/ratify/pkg/homedir"
 	"github.com/deislabs/ratify/pkg/ocispecs"
 	"github.com/deislabs/ratify/pkg/referrerstore"
@@ -133,16 +130,6 @@ func (s mockStore) GetSubjectDescriptor(ctx context.Context, subjectReference co
 	return &ocispecs.SubjectDescriptor{
 		Descriptor: ocispec.Descriptor{},
 	}, nil
-}
-
-type mockExecutor struct{}
-
-func (e mockExecutor) VerifySubject(ctx context.Context, verifyParameters e.VerifyParameters) (types.VerifyResult, error) {
-	return types.VerifyResult{}, nil
-}
-
-func (e mockExecutor) GetVerifyRequestTimeout() time.Duration {
-	return time.Hour
 }
 
 func TestName(t *testing.T) {

--- a/pkg/verifier/notaryv2/notaryv2_test.go
+++ b/pkg/verifier/notaryv2/notaryv2_test.go
@@ -62,7 +62,6 @@ var (
 	invalidRef = common.Reference{
 		Original: "invalid",
 	}
-	testExecutor                         = &mockExecutor{}
 	testNotaryVerifier notation.Verifier = mockNotaryVerifier{}
 	validBlobDesc                        = ocispec.Descriptor{
 		Digest: testDigest,

--- a/pkg/verifier/plugin/plugin.go
+++ b/pkg/verifier/plugin/plugin.go
@@ -92,7 +92,6 @@ func (vp *VerifierPlugin) Verify(ctx context.Context,
 	subjectReference common.Reference,
 	referenceDescriptor ocispecs.ReferenceDescriptor,
 	store referrerstore.ReferrerStore) (verifier.VerifierResult, error) {
-
 	referrerStoreConfig := store.GetConfig()
 	vr, err := vp.verifyReference(ctx, subjectReference, referenceDescriptor, referrerStoreConfig)
 	if err != nil {

--- a/pkg/verifier/plugin/plugin.go
+++ b/pkg/verifier/plugin/plugin.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/deislabs/ratify/pkg/common"
 	pluginCommon "github.com/deislabs/ratify/pkg/common/plugin"
-	e "github.com/deislabs/ratify/pkg/executor"
 	"github.com/deislabs/ratify/pkg/ocispecs"
 	"github.com/deislabs/ratify/pkg/referrerstore"
 	rc "github.com/deislabs/ratify/pkg/referrerstore/config"
@@ -92,44 +91,13 @@ func (vp *VerifierPlugin) Name() string {
 func (vp *VerifierPlugin) Verify(ctx context.Context,
 	subjectReference common.Reference,
 	referenceDescriptor ocispecs.ReferenceDescriptor,
-	store referrerstore.ReferrerStore,
-	executor e.Executor) (verifier.VerifierResult, error) {
-	var nestedResults []verifier.VerifierResult
-	if len(vp.nestedReferences) > 0 {
-		verifyParameters := e.VerifyParameters{
-			Subject:        fmt.Sprintf("%s@%s", subjectReference.Path, referenceDescriptor.Digest),
-			ReferenceTypes: vp.nestedReferences,
-		}
-		nestedVerifyResult, err := executor.VerifySubject(ctx, verifyParameters)
-
-		if err != nil {
-			return verifier.VerifierResult{IsSuccess: false}, err
-		}
-
-		for _, vr := range nestedVerifyResult.VerifierReports {
-			if result, ok := vr.(verifier.VerifierResult); ok {
-				nestedResults = append(nestedResults, result)
-			}
-		}
-
-		if !nestedVerifyResult.IsSuccess {
-			return verifier.VerifierResult{
-				Subject:       subjectReference.Original,
-				IsSuccess:     false,
-				Name:          vp.name,
-				Message:       "nested verification failed",
-				NestedResults: nestedResults,
-			}, nil
-		}
-	}
+	store referrerstore.ReferrerStore) (verifier.VerifierResult, error) {
 
 	referrerStoreConfig := store.GetConfig()
 	vr, err := vp.verifyReference(ctx, subjectReference, referenceDescriptor, referrerStoreConfig)
 	if err != nil {
 		return verifier.VerifierResult{IsSuccess: false}, err
 	}
-
-	vr.NestedResults = nestedResults
 
 	return *vr, nil
 }
@@ -172,4 +140,8 @@ func (vp *VerifierPlugin) verifyReference(
 	}
 
 	return result, nil
+}
+
+func (vp *VerifierPlugin) GetNestedReferences() []string {
+	return vp.nestedReferences
 }


### PR DESCRIPTION
# Description

## What this PR does / why we need it:
This PR moves the nested references logic out of plugins and into the executor while keeping the `nestedReferences` config values with Verifiers. There is no effective behavior change but it provides a clearer code execution. This lays out the initial changes for [decoupling nested references from verifiers](https://github.com/deislabs/ratify/issues/528)

- Moves verifying nested references out of `pkg/verifier/plugin/plugin.go` and into `pkg/executor/core/executor.go`
- Removes executor from `Verifier.Verify()`
- adds `GetNestedReferences` method for verifiers
    - notary signature verifier method returns empty slice because signatures should not check nested references 
- adds tests for nested references
    - `TestVerifySubject_NoNestedReferences_Expected`
    - `TestVerifySubject_NestedReferences_Expected`
- adds a test memory store to enable testing for nested references 
- Removes/modifies outdated nested references tests from of `pkg/verifier/plugin/plugin_test.go`
    - modifies existing test and adds one to check for IsSuccess (please comment if these tests were doing more than I thought, as they were not clear on what they were trying to accomplish. They appeared to be related to nested references but only checked for errors and IsSuccess)


Adding nested references to Verifiers works the same as before:

k8s
```yaml 
apiVersion: config.ratify.deislabs.io/v1alpha1
kind: Verifier
metadata:
  name: verifier-sbom
spec:
  name: sbom
  artifactTypes: org.example.sbom.v0
  parameters: 
    nestedReferences: any-string-here-enables-nested-references
```

cli
```json
      {
        "name": "sbom",
        "artifactTypes": "org.example.sbom.v0",
        "nestedReferences": "any-string-here-enables-nested-references"
      }
```


## Which issue(s) this PR fixes:
related to https://github.com/deislabs/ratify/issues/192

## Type of change

- [X] Cleaner execution flow (non-breaking change)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [X] TestVerifySubject_NoNestedReferences_Expected - executor 
- [X] TestVerifySubject_NestedReferences_Expected - executor 
- Modifies `pkg/verifier/plugin/plugin_test.go` as nested references are removed 

# Checklist:

- [X] Does the affected code have corresponding tests?
- [X] Do all new files have appropriate license header?
