### PR TITLE
feat: add request cache lock for verification

### DIFF
--- a/charts/ratify/templates/deployment.yaml
+++ b/charts/ratify/templates/deployment.yaml
@@ -48,6 +48,8 @@ spec:
             {{- if (lookup "v1" "Secret" .Release.Namespace "gatekeeper-webhook-server-cert") }}
             - --ca-cert-file=usr/local/tls/client-ca/ca.crt
             {{- end }}
+            - --cache-size={{ .Values.provider.cache.size }}
+            - --cache-ttl={{ .Values.provider.cache.ttl }}
           ports:
             - containerPort: 6001
           volumeMounts:
@@ -113,11 +115,11 @@ spec:
       volumes:
         - name: notary-certs
           secret:
-            secretName: {{ include "ratify.fullname" . }}-notary-certificate         
+            secretName: {{ include "ratify.fullname" . }}-notary-certificate
         {{- if .Values.cosign.enabled }}
         - name: cosign-certs
           secret:
-            secretName: {{ include "ratify.fullname" . }}-cosign-certificate         
+            secretName: {{ include "ratify.fullname" . }}-cosign-certificate
         {{- end }}
         {{- if $dockerAuthMode }}
         - name: dockerconfig

--- a/charts/ratify/values.yaml
+++ b/charts/ratify/values.yaml
@@ -95,6 +95,9 @@ provider:
     # timeout values must match gatekeeper webhook timeouts
     validationTimeoutSeconds: 5
     mutationTimeoutSeconds: 2
+  cache:
+    ttl: 10s  # cache ttl duration
+    size: 100 # number of items to be kept in cache. Set to 0 to disable cache.
 
 podAnnotations: {}
 podLabels: {}
@@ -102,7 +105,7 @@ enableRuntimeDefaultSeccompProfile: true
 
 rbac:
   create: true
-  
+
 upgradeCRDs:
   enabled: true
   extraRules: []
@@ -125,4 +128,3 @@ crds:
 # See https://github.com/deislabs/ratify/blob/main/docs/reference/usage.md for a list of available feature flags
 featureFlags:
   # RATIFY_FEATURE_NAME: true
-

--- a/httpserver/cache.go
+++ b/httpserver/cache.go
@@ -1,0 +1,50 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package httpserver
+
+import (
+	"time"
+
+	"github.com/deislabs/ratify/pkg/executor/types"
+	utilcache "k8s.io/apimachinery/pkg/util/cache"
+)
+
+type simpleCache struct {
+	cache   *utilcache.LRUExpireCache
+	ttl     time.Duration
+	maxSize int
+}
+
+func newSimpleCache(ttl time.Duration, maxSize int) *simpleCache {
+	return &simpleCache{
+		cache:   utilcache.NewLRUExpireCache(maxSize),
+		ttl:     ttl,
+		maxSize: maxSize,
+	}
+}
+
+// given a key, return the item from the cache if it exists and has not expired
+func (c *simpleCache) get(key string) *types.VerifyResult {
+	if item, ok := c.cache.Get(key); ok {
+		return item.(*types.VerifyResult)
+	}
+	return nil
+}
+
+// given a key, set the item in the cache
+func (c *simpleCache) set(key string, item *types.VerifyResult) {
+	c.cache.Add(key, item, c.ttl)
+}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"flag"
 	"os"
+	"time"
 
 	_ "github.com/deislabs/ratify/pkg/policyprovider/configpolicy"
 	_ "github.com/deislabs/ratify/pkg/referrerstore/oras"
@@ -61,7 +62,7 @@ func init() {
 	//+kubebuilder:scaffold:scheme
 }
 
-func StartServer(httpServerAddress string, configFilePath string, certDirectory string, caCertFile string) {
+func StartServer(httpServerAddress, configFilePath, certDirectory, caCertFile string, cacheSize int, cacheTTL time.Duration) {
 	logrus.Info("initializing executor with config file at default config path")
 
 	cf, err := config.Load(configFilePath)
@@ -71,7 +72,6 @@ func StartServer(httpServerAddress string, configFilePath string, certDirectory 
 	}
 
 	configStores, configVerifiers, policy, err := config.CreateFromConfig(cf)
-
 	if err != nil {
 		logrus.Warnf("error initializing from config %v", err)
 		os.Exit(1)
@@ -110,7 +110,7 @@ func StartServer(httpServerAddress string, configFilePath string, certDirectory 
 			Config:         &cf.ExecutorConfig,
 		}
 		return &executor
-	}, certDirectory, caCertFile)
+	}, certDirectory, caCertFile, cacheSize, cacheTTL)
 
 	if err != nil {
 		os.Exit(1)

--- a/test/bats/test.bats
+++ b/test/bats/test.bats
@@ -63,7 +63,8 @@ SLEEP_TIME=1
     assert_failure
 
     run kubectl apply -f ./config/samples/config_v1alpha1_verifier_complete_licensechecker.yaml
-    sleep 5
+    # wait for the httpserver cache to be invalidated
+    sleep 15
     run kubectl run license-checker2 --namespace default --image=wabbitnetworks.azurecr.io/test/license-checker-image:v1
     assert_success
 }
@@ -88,6 +89,8 @@ SLEEP_TIME=1
 
     run kubectl delete verifiers.config.ratify.deislabs.io/verifier-sbom
     assert_success
+    # wait for the httpserver cache to be invalidated
+    sleep 15
     run kubectl run sbom2 --namespace default --image=wabbitnetworks.azurecr.io/test/sbom-image:signed
     assert_failure
 }
@@ -110,14 +113,16 @@ SLEEP_TIME=1
 
     run kubectl apply -f ./config/samples/config_v1alpha1_verifier_schemavalidator.yaml
     sleep 5
-    # TODO 
+    # TODO
     # It's best to use an image with individual artifact types vs an all-in-one so any failures can be isolated.
     # Replace this image reference once we have a local private registry for Ratify.
     run kubectl run schemavalidator --namespace default --image=wabbitnetworks.azurecr.io/test/all-in-one-image:signed
     assert_success
 
     run kubectl apply -f ./config/samples/config_v1alpha1_verifier_schemavalidator_bad.yaml
-    sleep 5
+    assert_success
+    # wait for the httpserver cache to be invalidated
+    sleep 15
     run kubectl run schemavalidator2 --namespace default --image=wabbitnetworks.azurecr.io/test/all-in-one-image:signed
     assert_failure
 }
@@ -145,6 +150,8 @@ SLEEP_TIME=1
     run kubectl apply -f ./config/samples/config_v1alpha1_verifier_schemavalidator.yaml
     sleep 5
 
+    # wait for the httpserver cache to be invalidated
+    sleep 15
     run kubectl run all-in-one --namespace default --image=wabbitnetworks.azurecr.io/test/all-in-one-image:signed
     assert_success
 }
@@ -160,6 +167,8 @@ SLEEP_TIME=1
     assert_success
     run kubectl delete verifiers.config.ratify.deislabs.io/verifier-notary
     assert_success
+    # wait for the httpserver cache to be invalidated
+    sleep 15
     run kubectl run crdtest --namespace default --image=wabbitnetworks.azurecr.io/test/notary-image:signed
     assert_failure
 
@@ -167,6 +176,8 @@ SLEEP_TIME=1
     run kubectl apply -f ./config/samples/config_v1alpha1_verifier_notary.yaml
     assert_success
 
+    # wait for the httpserver cache to be invalidated
+    sleep 15
     run kubectl run crdtest --namespace default --image=wabbitnetworks.azurecr.io/test/notary-image:signed
     assert_success
 }


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

# Description

## What this PR does / why we need it:
<!--Please include a summary of the changes and relevant context. -->
- Adds request cache lock to enable processing verification once per subject in case of concurrent requests. The verification results are cached with a 5min TTL and refreshed if the cache entry is expired at read time. 

## Which issue(s) this PR fixes *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #507 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?
