### PR TITLE
fix: add pod label for workload identity

### DIFF
--- a/charts/ratify/templates/deployment.yaml
+++ b/charts/ratify/templates/deployment.yaml
@@ -14,6 +14,9 @@ spec:
     metadata:
       labels:
         {{- include "ratify.selectorLabels" . | nindent 8 }}
+        {{- if .Values.oras.authProviders.azureWorkloadIdentityEnabled }}
+        azure.workload.identity/use: "true"
+        {{- end }}
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:


### PR DESCRIPTION
# Description

## What this PR does / why we need it:

Adds the required pod label for [Azure Workload Identity](https://azure.github.io/azure-workload-identity/docs/topics/service-account-labels-and-annotations.html) when the corresponding Helm value is enabled

Handles the immediate blocker for #629, but doesn't address the further discussion points in the issue

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)