### PR TITLE
fix: remove unused authProvider field in cosign verifier

### DIFF
--- a/plugins/verifier/cosign/cosign.go
+++ b/plugins/verifier/cosign/cosign.go
@@ -52,8 +52,7 @@ type PluginConfig struct {
 }
 
 type StoreConfig struct {
-	UseHttp      bool   `json:"useHttp,omitempty"`
-	AuthProvider string `json:"authProvider,omitempty"`
+	UseHttp bool `json:"useHttp,omitempty"`
 }
 
 type StoreWrapperConfig struct {
@@ -154,10 +153,6 @@ func signatures(ctx context.Context, img string, keyRef string, config *PluginIn
 		if err != nil {
 			return nil, false, fmt.Errorf("failed to create Rekor client from URL %s: %w", config.Config.RekorURL, err)
 		}
-	}
-
-	if config.StoreWrapperConfig.StoreConfig.AuthProvider != "" {
-		return nil, false, fmt.Errorf("auth provider %s is not supported", config.StoreWrapperConfig.StoreConfig.AuthProvider)
 	}
 
 	return cosign.VerifyImageSignatures(ctx, ref, cosignOpts)


### PR DESCRIPTION
# Description

## What this PR does / why we need it:
- Removes the auth provider field in cosign
- This field was never used and a new change to the name in the struct caused a type mismatch when deserializing.

## Which issue(s) this PR fixes *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #655 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- All Azure tests pass on local fork

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?
