### PR TITLE
test: use replace to force useHttp flag update

### DIFF
--- a/config/samples/config_v1alpha1_store_oras_http.yaml
+++ b/config/samples/config_v1alpha1_store_oras_http.yaml
@@ -7,6 +7,7 @@ spec:
   parameters:
     cacheEnabled: true
     capacity: 100
-    cosignEnabled: false
+    cosignEnabled: true
     keyNumber: 10000
     ttl: 10
+    useHttp: true

--- a/test/bats/test.bats
+++ b/test/bats/test.bats
@@ -54,23 +54,18 @@ SLEEP_TIME=1
     }
     # update the config to use the keyless verifier since ratify doesn't support multiple verifiers of same type
     sed -i 's/\/usr\/local\/ratify-certs\/cosign\/cosign.pub/""/g' ./config/samples/config_v1alpha1_verifier_cosign.yaml
-    cat ./config/samples/config_v1alpha1_verifier_cosign.yaml >&3
     run kubectl apply -f ./config/samples/config_v1alpha1_verifier_cosign.yaml
     sleep 5
 
-    sed -i 's/useHttp: true/useHttp: false/' ./config/samples/config_v1alpha1_store_oras.yaml
-    sed -i 's/cosignEnabled: false/cosignEnabled: true/' ./config/samples/config_v1alpha1_store_oras.yaml
-    cat ./config/samples/config_v1alpha1_store_oras.yaml >&3
-    run kubectl apply -f ./config/samples/config_v1alpha1_store_oras.yaml
+    # use imperative command to guarantee useHttp is updated
+    run kubectl replace -f ./config/samples/config_v1alpha1_store_oras.yaml
     sleep 5
 
     run kubectl run cosign-demo-keyless --namespace default --image=wabbitnetworks.azurecr.io/test/cosign-image:signed-keyless
     assert_success
 
-    sed -i 's/useHttp: false/useHttp: true/' ./config/samples/config_v1alpha1_store_oras.yaml
     sed -i 's/""/\/usr\/local\/ratify-certs\/cosign\/cosign.pub/g' ./config/samples/config_v1alpha1_verifier_cosign.yaml
-    cat ./config/samples/config_v1alpha1_store_oras.yaml >&3
-    run kubectl apply -f ./config/samples/config_v1alpha1_store_oras.yaml
+    run kubectl apply -f ./config/samples/config_v1alpha1_store_oras_http.yaml
 }
 
 @test "licensechecker test" {


### PR DESCRIPTION
# Description

## What this PR does / why we need it:
- adds new oras http enabled CRD sample file for test
- switches to `kubectl replace` instead of `kubectl apply` when deleting `useHttp` flag from store CRD

## Which issue(s) this PR fixes *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #650 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?
