### PR TITLE
fix: make notary cert optional rather than mandatory since it is not always required in helm ratify deploy

### DIFF
--- a/charts/ratify/templates/inline-certificate-provider.yaml
+++ b/charts/ratify/templates/inline-certificate-provider.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.notaryCert}} 
+{{- if .Values.notaryCert }} 
 apiVersion: config.ratify.deislabs.io/v1beta1
 kind: CertificateStore
 metadata:

--- a/charts/ratify/templates/inline-certificate-provider.yaml
+++ b/charts/ratify/templates/inline-certificate-provider.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.akvCertConfig.enabled false }}  
+{{- if .Values.notaryCert}} 
 apiVersion: config.ratify.deislabs.io/v1beta1
 kind: CertificateStore
 metadata:
@@ -6,5 +6,5 @@ metadata:
 spec:
   provider: inline
   parameters:
-    value: {{ required "You must provide .Values.notaryCert" .Values.notaryCert | quote }}
+    value: {{ .Values.notaryCert | quote }}
 {{- end }}


### PR DESCRIPTION
# Description

## What this PR does / why we need it:
The latest helm deployment with Ratify expects notaryCert which is used to pass the public key for Notary verifications as mandatory which is not as expected since Ratify can  be used for other use cases like cosign verification and aggregator 
where it is not necessary.
<img width="805" alt="Screenshot 2023-03-23 at 10 32 57 pm" src="https://user-images.githubusercontent.com/5260185/227204734-ca7bb3bc-a490-47dc-8c41-edb9acb1e549.png">

## Which issue(s) this PR fixes Fixes #
fixes #713 

## Type of change
Bug fix
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Did a helm deploy from local chart without notary cert param and it passed
helm install ratify \
ratify/ratify --atomic
--namespace gatekeeper-system --set-file cosign.key=./cosign.pub --set-file dockerConfig=./config.json
# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?

# Post Merge Requirements
- [x] MAINTAINERS: manually trigger the "Publish Package" workflow after merging any PR that indicates `Helm Chart Change`
