### PR TITLE
fix: pin licensechecker test to specific version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,8 @@ HELM_VERSION ?= 3.9.2
 BATS_TESTS_FILE ?= test/bats/test.bats
 BATS_CLI_TESTS_FILE ?= test/bats/cli-test.bats
 BATS_VERSION ?= 1.7.0
+SYFT_VERSION ?= v0.76.0
+ALPINE_IMAGE ?= alpine@sha256:93d5a28ff72d288d69b5997b8ba47396d2cbb62a72b5d87cd3351094b5d578a0
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.24.2
@@ -180,7 +182,7 @@ e2e-run-local-registry:
 e2e-create-all-image:
 	rm -rf .staging
 	mkdir .staging
-	echo 'FROM alpine\nCMD ["echo", "all-in-one image"]' > .staging/Dockerfile
+	echo 'FROM ${ALPINE_IMAGE}\nCMD ["echo", "all-in-one image"]' > .staging/Dockerfile
 	docker build --no-cache -t ${TEST_REGISTRY}/all:v0 .staging
 	docker push ${TEST_REGISTRY}/all:v0
 
@@ -218,7 +220,7 @@ e2e-notaryv2-setup:
 	curl -L https://github.com/notaryproject/notation/releases/download/v${NOTATION_VERSION}/notation_${NOTATION_VERSION}_linux_amd64.tar.gz --output ${GITHUB_WORKSPACE}/.staging/notaryv2/notation.tar.gz
 	tar -zxvf ${GITHUB_WORKSPACE}/.staging/notaryv2/notation.tar.gz -C ${GITHUB_WORKSPACE}/.staging/notaryv2
 
-	echo 'FROM alpine\nCMD ["echo", "notaryv2 signed image"]' > .staging/notaryv2/Dockerfile
+	echo 'FROM ${ALPINE_IMAGE}\nCMD ["echo", "notaryv2 signed image"]' > .staging/notaryv2/Dockerfile
 	docker build --no-cache -t ${TEST_REGISTRY}/notation:signed .staging/notaryv2
 	docker push ${TEST_REGISTRY}/notation:signed
 
@@ -234,7 +236,7 @@ e2e-notaryv2-setup:
 
 	# OCI 1.1 Artifact Resources
 	if [ ${IS_OCI_1_1} = 'true' ]; then \
-		echo 'FROM alpine\nCMD ["echo", "notaryv2 signed image oci artifact"]' > .staging/notaryv2/Dockerfile && \
+		echo 'FROM ${ALPINE_IMAGE}\nCMD ["echo", "notaryv2 signed image oci artifact"]' > .staging/notaryv2/Dockerfile && \
 		docker build --no-cache -t ${TEST_REGISTRY}/notation:ociartifact .staging/notaryv2 && \
 		docker push ${TEST_REGISTRY}/notation:ociartifact && \
 		.staging/notaryv2/notation sign --signature-manifest artifact -u ${TEST_REGISTRY_USERNAME} -p ${TEST_REGISTRY_PASSWORD} `docker image inspect ${TEST_REGISTRY}/notation:ociartifact | jq -r .[0].RepoDigests[0]`; \
@@ -250,7 +252,7 @@ e2e-notation-leaf-cert-setup:
 
 	jq '.keys += [{"name":"leaf-test","keyPath":".staging/notaryv2/leaf-test/leaf.key","certPath":".staging/notaryv2/leaf-test/leaf.crt"}]' ~/.config/notation/signingkeys.json > tmp && mv tmp ~/.config/notation/signingkeys.json
 
-	echo 'FROM alpine\nCMD ["echo", "notaryv2 leaf signed image"]' > .staging/notaryv2/Dockerfile
+	echo 'FROM ${ALPINE_IMAGE}\nCMD ["echo", "notaryv2 leaf signed image"]' > .staging/notaryv2/Dockerfile
 	docker build --no-cache -t ${TEST_REGISTRY}/notation:leafSigned .staging/notaryv2
 	docker push ${TEST_REGISTRY}/notation:leafSigned
 	.staging/notaryv2/notation sign -u ${TEST_REGISTRY_USERNAME} -p ${TEST_REGISTRY_PASSWORD} --key "leaf-test" `docker image inspect ${TEST_REGISTRY}/notation:leafSigned | jq -r .[0].RepoDigests[0]`
@@ -263,7 +265,7 @@ e2e-cosign-setup:
 	chmod +x .staging/cosign/cosign-linux-amd64
 
 	# image signed with a key
-	echo 'FROM alpine\nCMD ["echo", "cosign signed image"]' > .staging/cosign/Dockerfile
+	echo 'FROM ${ALPINE_IMAGE}\nCMD ["echo", "cosign signed image"]' > .staging/cosign/Dockerfile
 	docker build --no-cache -t ${TEST_REGISTRY}/cosign:signed-key .staging/cosign
 	docker push ${TEST_REGISTRY}/cosign:signed-key
 
@@ -283,10 +285,10 @@ e2e-licensechecker-setup:
 	mkdir -p .staging/licensechecker
 
 	# Install Syft
-	curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b .staging/licensechecker
+	curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b .staging/licensechecker ${SYFT_VERSION}
 
 	# Build/Push Image
-	echo 'FROM alpine@sha256:93d5a28ff72d288d69b5997b8ba47396d2cbb62a72b5d87cd3351094b5d578a0\nCMD ["echo", "licensechecker image"]' > .staging/licensechecker/Dockerfile
+	echo 'FROM ${ALPINE_IMAGE}\nCMD ["echo", "licensechecker image"]' > .staging/licensechecker/Dockerfile
 	docker build --no-cache -t ${TEST_REGISTRY}/licensechecker:v0 .staging/licensechecker
 	docker push ${TEST_REGISTRY}/licensechecker:v0
 
@@ -301,7 +303,7 @@ e2e-licensechecker-setup:
 
 	# OCI 1.1 Artifact Resources
 	if [ ${IS_OCI_1_1} = 'true' ]; then \
-		echo 'FROM alpine@sha256:93d5a28ff72d288d69b5997b8ba47396d2cbb62a72b5d87cd3351094b5d578a0\nCMD ["echo", "licensechecker image oci artifact"]' > .staging/licensechecker/Dockerfile && \
+		echo 'FROM ${ALPINE_IMAGE}\nCMD ["echo", "licensechecker image oci artifact"]' > .staging/licensechecker/Dockerfile && \
 		docker build -t ${TEST_REGISTRY}/licensechecker:ociartifact .staging/licensechecker && \
 		docker push ${TEST_REGISTRY}/licensechecker:ociartifact && \
 		${GITHUB_WORKSPACE}/bin/oras attach ${TEST_REGISTRY}/licensechecker:ociartifact \
@@ -318,10 +320,10 @@ e2e-sbom-setup:
 	curl -Lo .staging/sbom/sbom-tool https://github.com/microsoft/sbom-tool/releases/latest/download/sbom-tool-linux-x64 && chmod +x .staging/sbom/sbom-tool
 
 	# Build/Push Images
-	echo 'FROM alpine\nCMD ["echo", "sbom image"]' > .staging/sbom/Dockerfile
+	echo 'FROM ${ALPINE_IMAGE}\nCMD ["echo", "sbom image"]' > .staging/sbom/Dockerfile
 	docker build --no-cache -t ${TEST_REGISTRY}/sbom:v0 .staging/sbom
 	docker push ${TEST_REGISTRY}/sbom:v0
-	echo 'FROM alpine\nCMD ["echo", "sbom image unsigned"]' > .staging/sbom/Dockerfile
+	echo 'FROM ${ALPINE_IMAGE}\nCMD ["echo", "sbom image unsigned"]' > .staging/sbom/Dockerfile
 	docker build --no-cache -t ${TEST_REGISTRY}/sbom:unsigned .staging/sbom
 	docker push ${TEST_REGISTRY}/sbom:unsigned
 
@@ -346,7 +348,7 @@ e2e-sbom-setup:
 
 	# OCI 1.1 Artifact Resources
 	if [ ${IS_OCI_1_1} = 'true' ]; then \
-		echo 'FROM alpine\nCMD ["echo", "sbom image oci artifact"]' > .staging/sbom/Dockerfile && \
+		echo 'FROM ${ALPINE_IMAGE}\nCMD ["echo", "sbom image oci artifact"]' > .staging/sbom/Dockerfile && \
 		docker build --no-cache -t ${TEST_REGISTRY}/sbom:ociartifact .staging/sbom && \
 		docker push ${TEST_REGISTRY}/sbom:ociartifact && \
 		${GITHUB_WORKSPACE}/bin/oras attach \
@@ -366,7 +368,7 @@ e2e-schemavalidator-setup:
 	tar -zxf .staging/schemavalidator/trivy.tar.gz -C .staging/schemavalidator
 
 	# Build/Push Images
-	echo 'FROM alpine\nCMD ["echo", "schemavalidator image"]' > .staging/schemavalidator/Dockerfile
+	echo 'FROM ${ALPINE_IMAGE}\nCMD ["echo", "schemavalidator image"]' > .staging/schemavalidator/Dockerfile
 	docker build --no-cache -t ${TEST_REGISTRY}/schemavalidator:v0 .staging/schemavalidator
 	docker push ${TEST_REGISTRY}/schemavalidator:v0
 
@@ -383,7 +385,7 @@ e2e-schemavalidator-setup:
 	
 	# OCI 1.1 Artifact Resources
 	if [ ${IS_OCI_1_1} = 'true' ]; then \
-		echo 'FROM alpine\nCMD ["echo", "schemavalidator image oci artifact"]' > .staging/schemavalidator/Dockerfile && \
+		echo 'FROM ${ALPINE_IMAGE}\nCMD ["echo", "schemavalidator image oci artifact"]' > .staging/schemavalidator/Dockerfile && \
 		docker build --no-cache -t ${TEST_REGISTRY}/schemavalidator:ociartifact .staging/schemavalidator && \
 		docker push ${TEST_REGISTRY}/schemavalidator:ociartifact && \
 		${GITHUB_WORKSPACE}/bin/oras attach \
@@ -398,7 +400,7 @@ e2e-inlinecert-setup:
 	mkdir -p .staging/inlinecert
 
 	# build and sign an image with an alternate certificate
-	echo 'FROM alpine\nCMD ["echo", "alternate notaryv2 signed image"]' > .staging/inlinecert/Dockerfile
+	echo 'FROM ${ALPINE_IMAGE}\nCMD ["echo", "alternate notaryv2 signed image"]' > .staging/inlinecert/Dockerfile
 	docker build --no-cache -t ${TEST_REGISTRY}/notation:signed-alternate .staging/inlinecert
 	docker push ${TEST_REGISTRY}/notation:signed-alternate
 

--- a/config/samples/config_v1beta1_verifier_complete_licensechecker.yaml
+++ b/config/samples/config_v1beta1_verifier_complete_licensechecker.yaml
@@ -15,5 +15,8 @@ spec:
     - MPL-2.0 AND MIT
     - ISC
     - Apache-2.0
-    - MIT AND BSD-2-Clause AND GPL-2.0-or-later
+    - MIT AND BSD-2-Clause AND GPL-2.0-or-later,
+    - MIT AND LicenseRef-AND AND BSD-2-Clause AND LicenseRef-AND AND GPL-2.0-or-later
+    - MPL-2.0 AND LicenseRef-AND AND MIT
+    - BSD-2-Clause AND LicenseRef-AND AND BSD-3-Clause
     - NONE

--- a/test/bats/tests/config/complete_licensechecker_config.json
+++ b/test/bats/tests/config/complete_licensechecker_config.json
@@ -33,6 +33,9 @@
                     "ISC",
                     "Apache-2.0",
                     "MIT AND BSD-2-Clause AND GPL-2.0-or-later",
+                    "MIT AND LicenseRef-AND AND BSD-2-Clause AND LicenseRef-AND AND GPL-2.0-or-later",
+                    "MPL-2.0 AND LicenseRef-AND AND MIT",
+                    "BSD-2-Clause AND LicenseRef-AND AND BSD-3-Clause",
                     "NONE"
                 ]
             }

--- a/test/bats/tests/config/config.json
+++ b/test/bats/tests/config/config.json
@@ -82,6 +82,9 @@
                     "ISC",
                     "Apache-2.0",
                     "MIT AND BSD-2-Clause AND GPL-2.0-or-later",
+                    "MIT AND LicenseRef-AND AND BSD-2-Clause AND LicenseRef-AND AND GPL-2.0-or-later",
+                    "MPL-2.0 AND LicenseRef-AND AND MIT",
+                    "BSD-2-Clause AND LicenseRef-AND AND BSD-3-Clause",
                     "NONE"
                 ]
             }

--- a/test/bats/tests/config/cosign_keyless_config.json
+++ b/test/bats/tests/config/cosign_keyless_config.json
@@ -80,6 +80,9 @@
                     "ISC",
                     "Apache-2.0",
                     "MIT AND BSD-2-Clause AND GPL-2.0-or-later",
+                    "MIT AND LicenseRef-AND AND BSD-2-Clause AND LicenseRef-AND AND GPL-2.0-or-later",
+                    "MPL-2.0 AND LicenseRef-AND AND MIT",
+                    "BSD-2-Clause AND LicenseRef-AND AND BSD-3-Clause",
                     "NONE"
                 ]
             }


### PR DESCRIPTION
# Description

## What this PR does / why we need it:
- pins Syft version to a specific tag
- switches all alpine base images to a specific digest
- updates configs for newly added licenses

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Helm Chart Change (any edit/addition/update that is necessary for changes merged to the `main` branch)
- [ ] This change requires a documentation update

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?

# Post Merge Requirements
- [ ] MAINTAINERS: manually trigger the "Publish Package" workflow after merging any PR that indicates `Helm Chart Change`
