### PR TITLE
fix: add time delay for prometheus exporter test

### DIFF
--- a/pkg/metrics/prometheus_exporter_test.go
+++ b/pkg/metrics/prometheus_exporter_test.go
@@ -18,12 +18,14 @@ package metrics
 import (
 	"net/http"
 	"testing"
+	"time"
 )
 
 func TestInitPrometheusExporter(t *testing.T) {
 	if err := initPrometheusExporter(8888); err != nil {
 		t.Fatalf("initPrometheusExporter() error = %v", err)
 	}
+	time.Sleep(2 * time.Second)
 	r, err := http.NewRequest("GET", "http://localhost:8888/metrics", nil)
 	if err != nil {
 		t.Fatalf("http.NewRequest() error = %v", err)


### PR DESCRIPTION
# Description

## What this PR does / why we need it:
The prometheus exporter test starts up a local server for testing. This server can take time to start up and exists in the same context as the requests being sent to it. As a result, there can be some runs when the server is not ready in time to accept requests causing test flakiness. This PR adds a 2 second delay for server initialization buffer. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Helm Chart Change (any edit/addition/update that is necessary for changes merged to the `main` branch)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Unit tests pass

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?

# Post Merge Requirements
- [ ] MAINTAINERS: manually trigger the "Publish Package" workflow after merging any PR that indicates `Helm Chart Change`
