### PR TITLE
feat: add pre-install hook to Ratify CRs

### DIFF
--- a/charts/ratify/templates/akv-certificate-provider.yaml
+++ b/charts/ratify/templates/akv-certificate-provider.yaml
@@ -3,6 +3,9 @@ apiVersion: config.ratify.deislabs.io/v1beta1
 kind: CertificateStore
 metadata:
   name: certstore-akv
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "5"
 spec:
   provider: azurekeyvault
   parameters:

--- a/charts/ratify/templates/inline-certificate-provider.yaml
+++ b/charts/ratify/templates/inline-certificate-provider.yaml
@@ -3,6 +3,9 @@ apiVersion: config.ratify.deislabs.io/v1beta1
 kind: CertificateStore
 metadata:
   name: {{ include "ratify.fullname" . }}-notary-inline-cert
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "5"
 spec:
   provider: inline
   parameters:

--- a/charts/ratify/templates/store.yaml
+++ b/charts/ratify/templates/store.yaml
@@ -2,6 +2,9 @@ apiVersion: config.ratify.deislabs.io/v1beta1
 kind: Store
 metadata:
   name: store-oras
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "5"
 spec:
   name: oras
   parameters:

--- a/charts/ratify/templates/verifier.yaml
+++ b/charts/ratify/templates/verifier.yaml
@@ -2,6 +2,9 @@ apiVersion: config.ratify.deislabs.io/v1beta1
 kind: Verifier
 metadata:
   name: verifier-notary
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "5"
 spec:
   name: notaryv2
   artifactTypes: application/vnd.cncf.notary.signature
@@ -32,6 +35,9 @@ apiVersion: config.ratify.deislabs.io/v1beta1
 kind: Verifier
 metadata:
   name: verifier-cosign
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "5"
 spec:
   name: cosign
   artifactTypes: application/vnd.dev.cosign.artifact.sig.v1+json


### PR DESCRIPTION
# Description

## What this PR does / why we need it:
Add pre-install hook to CR templates so that they could be skipped rendering and only be installed after CRDs are updated.

## Which issue(s) this PR fixes *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes https://github.com/deislabs/ratify/issues/765

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Helm Chart Change (any edit/addition/update that is necessary for changes merged to the `main` branch)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally with v1alpha1 CRDs, the new chart could be deployed successfully with CRDs upgraded to v1beta1.

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?

# Post Merge Requirements
- [ ] MAINTAINERS: manually trigger the "Publish Package" workflow after merging any PR that indicates `Helm Chart Change`
