### PR TITLE
fix: publish ratify image with plugin 

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -27,6 +27,7 @@ jobs:
           DATE=$(date +'%Y%m%d')
           COMMIT=${{ github.sha }}
           REPOSITORY=ghcr.io/${{ github.repository }}
+          REPOSITORYBASE=ghcr.io/${{ github.repository }}-base
           REPOSITORYCRD=ghcr.io/${{ github.repository }}-crds
           if [[ "${VERSION}" == "${BRANCH_NAME}" ]]; then
             VERSION=$(git rev-parse --short HEAD)
@@ -34,14 +35,19 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" || "${{ github.event_name }}" == "schedule" ]]; then
             VERSION=dev.${DATE}.${COMMIT:0:7}
             REPOSITORY=${REPOSITORY}-dev
+            REPOSITORYBASE=${REPOSITORYBASE}-dev
             REPOSITORYCRD=${REPOSITORYCRD}-dev
           fi
           echo ::set-output name=version::${VERSION}
           echo ::set-output name=ref::${REPOSITORY}:${VERSION}
+          echo ::set-output name=baseref::${REPOSITORYBASE}:${VERSION}
           echo ::set-output name=crdref::${REPOSITORYCRD}:${VERSION}
-      - name: docker build ratify
+      - name: docker build ratify base
         run: |
-          docker build -f ./httpserver/Dockerfile --label org.opencontainers.image.revision=${{ github.sha }} -t ${{ steps.prepare.outputs.ref }} .
+          docker build -f ./httpserver/Dockerfile --label org.opencontainers.image.revision=${{ github.sha }} -t ${{ steps.prepare.outputs.baseref }} .
+      - name: docker build ratify with plugin
+        run: |
+          docker build -f ./httpserver/Dockerfile --build-arg build_cosign=true --build-arg build_sbom=true --build-arg build_licensechecker=true --build-arg build_schemavalidator=true --label org.opencontainers.image.revision=${{ github.sha }} -t ${{ steps.prepare.outputs.ref }} .
       - name: docker build ratify-crds
         run: |
           docker build --build-arg KUBE_VERSION="1.25.4" --build-arg TARGETOS="linux" --build-arg TARGETARCH="amd64" -f crd.Dockerfile --label org.opencontainers.image.revision=${{ github.sha }} -t ${{ steps.prepare.outputs.crdref }} ./charts/ratify/crds
@@ -51,7 +57,10 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: docker push ratify
+      - name: docker push ratify base
+        run: |
+          docker push ${{ steps.prepare.outputs.baseref }}
+      - name: docker push ratify with plugin
         run: |
           docker push ${{ steps.prepare.outputs.ref }}
       - name: docker push ratify-crds


### PR DESCRIPTION
# Description

## What this PR does / why we need it:
We updated the build step to optionally build the plugin, see PR [860], (https://github.com/deislabs/ratify/pull/860/files#diff-9c427950275d8aad2e8016fd20f5615c15acda7205793165fe31d45748ee0e9d), but our publish workflow is not currently passing in of the params.
The immdiate fix , we need to update our publish workflow to build ratify image with the plugin.  We also have a test gap here , we should also have test run against latest released version
## Which issue(s) this PR fixes :
Fixes # 915

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Helm Chart Change (any edit/addition/update that is necessary for changes merged to the `main` branch)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?

# Post Merge Requirements
- [ ] MAINTAINERS: manually trigger the "Publish Package" workflow after merging any PR that indicates `Helm Chart Change`
