### PR TITLE
chore: add triage label to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -14,7 +14,7 @@
 #template created based on verbiage from https://github.com/oras-project/oras/blob/cc40e430ee0cc124250f9855a2e99f535f759221/.github/ISSUE_TEMPLATE/bug-report.yaml
 name: Bug Report
 description: File a bug report
-labels: [bug]
+labels: [bug, triage]
 body:
   - type: markdown
     id: preface

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -15,7 +15,7 @@
 #Template created based on verbiage from https://github.com/oras-project/oras/blob/cc40e430ee0cc124250f9855a2e99f535f759221/.github/ISSUE_TEMPLATE/feature-request.yaml
 name: Feature Request
 description: File a feature request
-labels: [enhancement]
+labels: [enhancement, triage]
 body:
   - type: markdown
     id: preface


### PR DESCRIPTION
Signed-off-by: Yi Zha <yizha1@microsoft.com>

# Description

## What this PR does / why we need it:
The `triage` label indicates the issue or PR needs triage. This PR adds `triage` label for a newly created issue, since every new issue needs to be triaged. Once an issue is triaged, we can then remove the `triage` label. With this label and process, it will improve the efficiency of our issue management. For example, we can easily filter out all the issues that are not triaged.

## Which issue(s) this PR fixes *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Helm Chart Change (any edit/addition/update that is necessary for changes merged to the `main` branch)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?

# Post Merge Requirements
- [ ] MAINTAINERS: manually trigger the "Publish Package" workflow after merging any PR that indicates `Helm Chart Change`
