### PR TITLE
feat: optional image mutation in helm chart

### DIFF
--- a/charts/ratify/templates/assign.yaml
+++ b/charts/ratify/templates/assign.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.provider.enableMutation -}}
 {{ include "ratify.assignGKVersion" . }}
 kind: Assign
 metadata:
@@ -63,4 +64,4 @@ spec:
     assign:
       externalData:
         provider: ratify-mutation-provider
- 
+{{- end }}

--- a/charts/ratify/templates/provider.yaml
+++ b/charts/ratify/templates/provider.yaml
@@ -17,6 +17,7 @@ spec:
   timeout: {{ required "You must provide .Values.provider.timeout.validationTimeoutSeconds" .Values.provider.timeout.validationTimeoutSeconds }}
   {{ include "ratify.providerCabundle" (list . $ca) | nindent 2}}
 
+{{- if .Values.provider.enableMutation }}
 ---
 
 {{ include "ratify.providerGKVersion" . }}
@@ -30,7 +31,7 @@ spec:
   url: https://{{ include "ratify.fullname" .}}.{{ .Release.Namespace }}:6001/ratify/gatekeeper/v1/mutate
   timeout: {{ required "You must provide .Values.provider.timeout.mutationTimeoutSeconds" .Values.provider.timeout.mutationTimeoutSeconds }}
   {{ include "ratify.providerCabundle" (list . $ca) | nindent 2}}
-
+{{- end }}
 ---
 
 apiVersion: v1

--- a/charts/ratify/values.yaml
+++ b/charts/ratify/values.yaml
@@ -83,6 +83,7 @@ provider:
     cacheSizeMb: 256 # max size of the cache in MB
     ttl: 10s # cache ttl duration
     name: "" # state-store name for dapr cache, defaults to redis
+  enableMutation: true # enableMutation allows ratify to mutate image tag to image digest. It is highly recommended to enable mutation since the verified digest may be different from the one run.
 
 podAnnotations: {}
 podLabels: {}

--- a/httpserver/handlers.go
+++ b/httpserver/handlers.go
@@ -79,6 +79,9 @@ func (server *Server) verify(ctx context.Context, w http.ResponseWriter, r *http
 				returnItem.Error = err.Error()
 				return
 			}
+			if subjectReference.Digest.String() == "" {
+				logrus.Warn("Digest should be used instead of tagged reference. The resolved digest may not point to the same signed artifact, since tags are mutable.")
+			}
 			resolvedSubjectReference := subjectReference.Original
 			unlock := server.keyMutex.Lock(resolvedSubjectReference)
 			defer unlock()


### PR DESCRIPTION
# Description
Allow image mutation to be optional in helm chart. This change introduces one new property in helm chart under provider.
`provider.enableMutation=true`
When `provider.enableMutation` is set to false, it disables creation of
1. All mutation assign CRDs
2. ratify-mutation provider CRD

## What this PR does / why we need it:
Current ratify helm chart allows image mutation by default. All image tags are replaced with image digest. This may not be desirable in some use cases. E.g. if there are OPA gatekeper constraints based on image tags or if the image tags reflects application revision.

## Which issue(s) this PR fixes *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #943 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Helm Chart Change (any edit/addition/update that is necessary for changes merged to the `main` branch)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Run `helm template ratify .` from within the helm chart repository. Generated yaml is same as current yaml.
- [x] Run `helm template ratify . --set provider.enableMutation=false` from within helm repository. Mutation assign CRDs and ratify-mutation provider CRD are removed from generated template.

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [x] Do all new files have appropriate license header?

# Post Merge Requirements
- [x] MAINTAINERS: manually trigger the "Publish Package" workflow after merging any PR that indicates `Helm Chart Change`
