### PR TITLE
feat: add version and OS/Arch to user-agent header

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -42,6 +42,9 @@ jobs:
           echo ::set-output name=ref::${REPOSITORY}:${VERSION}
           echo ::set-output name=baseref::${REPOSITORYBASE}:${VERSION}
           echo ::set-output name=crdref::${REPOSITORYCRD}:${VERSION}
+      - name: Get tag
+        run: |
+          echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
       - name: docker login
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
         with:
@@ -55,11 +58,25 @@ jobs:
       - name: docker build ratify base
         run: |
           docker buildx create --use         
-          docker buildx build -f ./httpserver/Dockerfile --platform linux/amd64,linux/arm64,linux/arm/v7 --label org.opencontainers.image.revision=${{ github.sha }} -t ${{ steps.prepare.outputs.baseref }} --push .
+          docker buildx build -f ./httpserver/Dockerfile \
+            --platform linux/amd64,linux/arm64,linux/arm/v7 \
+            --build-arg LDFLAGS="-X github.com/deislabs/ratify/internal/version.Version=$(TAG)" \
+            --label org.opencontainers.image.revision=${{ github.sha }} \
+            -t ${{ steps.prepare.outputs.baseref }} \
+            --push .
       - name: docker build ratify with plugin
         run: |
           docker buildx create --use
-          docker buildx build -f ./httpserver/Dockerfile --platform linux/amd64,linux/arm64,linux/arm/v7 --build-arg build_cosign=true --build-arg build_sbom=true --build-arg build_licensechecker=true --build-arg build_schemavalidator=true --label org.opencontainers.image.revision=${{ github.sha }} -t ${{ steps.prepare.outputs.ref }} --push .
+          docker buildx build -f ./httpserver/Dockerfile \
+            --platform linux/amd64,linux/arm64,linux/arm/v7 \
+            --build-arg build_cosign=true \
+            --build-arg build_sbom=true \
+            --build-arg build_licensechecker=true \
+            --build-arg build_schemavalidator=true \
+            --build-arg LDFLAGS="-X github.com/deislabs/ratify/internal/version.Version=$(TAG)" \
+            --label org.opencontainers.image.revision=${{ github.sha }} \
+            -t ${{ steps.prepare.outputs.ref }} \
+            --push .
       - name: clear
         if: always()
         run: |

--- a/httpserver/Dockerfile
+++ b/httpserver/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /app
 
 COPY . .
 
-RUN go build -o /app/out/ /app/cmd/ratify
+RUN go build -ldflags "${LDFLAGS}" -o /app/out/ /app/cmd/ratify
 RUN mkdir /app/out/plugins
 RUN if [ "$build_sbom" = "true" ]; then go build -o /app/out/plugins/ /app/plugins/verifier/sbom; fi
 RUN if [ "$build_cosign" = "true" ]; then go build -o /app/out/plugins/ /app/plugins/verifier/cosign; fi

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,17 @@
 package version
 
+import (
+	"fmt"
+	"runtime"
+	"runtime/debug"
+)
+
 var (
+	// Version is the current version of Ratify.
+	Version = ""
+
+	// UserAgent is the user agent for http request header.
+	UserAgent = ""
 
 	//GitTag
 	GitTag = ""
@@ -11,3 +22,23 @@ var (
 	//GitTreeState shows if the tree is unmodified or modified
 	GitTreeState = ""
 )
+
+func init() {
+	UserAgent = generateUserAgent()
+}
+
+func generateUserAgent() string {
+	vcsrevision := "unknown"
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, v := range info.Settings {
+			switch v.Key {
+			case "vcs.revision":
+				vcsrevision = v.Value
+			}
+		}
+	}
+	if Version == "" {
+		Version = vcsrevision
+	}
+	return fmt.Sprintf("%s+%s (%s/%s)", "ratify", Version, runtime.GOOS, runtime.GOARCH)
+}

--- a/pkg/common/plugin/download.go
+++ b/pkg/common/plugin/download.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/deislabs/ratify/internal/version"
 	"github.com/deislabs/ratify/pkg/common/oras/authprovider"
 	commonutils "github.com/deislabs/ratify/pkg/common/utils"
 	"github.com/deislabs/ratify/pkg/ocispecs"
@@ -67,7 +68,7 @@ func DownloadPlugin(source PluginSource, targetPath string) error {
 	repository.Client = &auth.Client{
 		Client: &http.Client{Timeout: 10 * time.Second, Transport: http.DefaultTransport.(*http.Transport).Clone()},
 		Header: http.Header{
-			"User-Agent": {"ratify"},
+			"User-Agent": {version.UserAgent},
 		},
 		Cache: auth.NewCache(),
 		Credential: func(ctx context.Context, registry string) (auth.Credential, error) {

--- a/pkg/referrerstore/oras/oras.go
+++ b/pkg/referrerstore/oras/oras.go
@@ -40,6 +40,7 @@ import (
 	ratifyconfig "github.com/deislabs/ratify/config"
 	re "github.com/deislabs/ratify/errors"
 	"github.com/deislabs/ratify/internal/logger"
+	"github.com/deislabs/ratify/internal/version"
 	"github.com/deislabs/ratify/pkg/cache"
 	"github.com/deislabs/ratify/pkg/common"
 	"github.com/deislabs/ratify/pkg/common/oras/authprovider"
@@ -447,14 +448,13 @@ func createDefaultRepository(ctx context.Context, store *orasStore, targetRef co
 
 	// set the repository client credentials
 	repoClient := &auth.Client{
-		Client: store.httpClient,
-		Header: http.Header{
-			"User-Agent": {ratifyUserAgent},
-		},
+		Client:     store.httpClient,
+		Header:     http.Header{},
 		Cache:      auth.NewCache(),
 		Credential: credentialProvider,
 	}
 
+	repoClient.SetUserAgent(version.UserAgent)
 	repoClient.Header = logger.SetTraceIDHeader(ctx, repoClient.Header)
 
 	// enable insecure if specified in config


### PR DESCRIPTION
# Description

## What this PR does / why we need it:
Add version and OS/Arch info to the user-agent header.

## Which issue(s) this PR fixes *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes https://github.com/deislabs/ratify/issues/1040

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Helm Chart Change (any edit/addition/update that is necessary for changes merged to the `main` branch)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Manually built image with `v1.0.0` tag and added a test log before setting the user-agent.
![MicrosoftTeams-image (5)](https://github.com/deislabs/ratify/assets/6919333/87650a7e-83c8-4380-994b-a90e61d1ef9c)



# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?

# Post Merge Requirements
- [ ] MAINTAINERS: manually trigger the "Publish Package" workflow after merging any PR that indicates `Helm Chart Change`
