### PR TITLE
fix: bump dev helmfile ratify chart versions

### DIFF
--- a/dev.helmfile.yaml
+++ b/dev.helmfile.yaml
@@ -23,7 +23,7 @@ releases:
   - name: ratify
     namespace: gatekeeper-system
     chart: charts/ratify # PRERELEASE: Change to 'ratify/ratify' before copying to helmfile.yaml
-    version: 1.11.0 # ATTENTION: Needs to match latest in Chart.yaml
+    version: 1.12.0 # ATTENTION: Needs to match latest in Chart.yaml
     wait: true
     needs:
       - gatekeeper

--- a/dev.high-availability.helmfile.yaml
+++ b/dev.high-availability.helmfile.yaml
@@ -32,7 +32,7 @@ releases:
   - name: ratify
     namespace: gatekeeper-system
     chart: charts/ratify/
-    version: 1.11.0 # ATTENTION: Needs to match latest in Chart.yaml
+    version: 1.12.0 # ATTENTION: Needs to match latest in Chart.yaml
     wait: true
     needs:
       - dapr-system/dapr


### PR DESCRIPTION
# Description

## What this PR does / why we need it:
- updates the dev helmfiles to use version 1.12.0 which is the v1.1.0 chart version equivalent. This was accidentally missed during release

## Which issue(s) this PR fixes *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Helm Chart Change (any edit/addition/update that is necessary for changes merged to the `main` branch)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?

# Post Merge Requirements
- [ ] MAINTAINERS: manually trigger the "Publish Package" workflow after merging any PR that indicates `Helm Chart Change`
