### PR TITLE
feat: add GetNamespace utils method for context [multi-tenancy PR 1]

### DIFF
--- a/httpserver/handlers.go
+++ b/httpserver/handlers.go
@@ -197,13 +197,19 @@ func (server *Server) mutate(ctx context.Context, w http.ResponseWriter, r *http
 				returnItem.Error = err.Error()
 				return
 			}
-			parsedReference, err := pkgUtils.ParseSubjectReference(image)
+			requestKey, err := pkgUtils.ParseRequestKey(image)
+			if err != nil {
+				returnItem.Error = err.Error()
+				return
+			}
+			parsedReference, err := pkgUtils.ParseSubjectReference(requestKey.Subject)
 			if err != nil {
 				err = errors.ErrorCodeReferenceInvalid.WithError(err).WithDetail(fmt.Sprintf("failed to parse image reference %s", image))
 				logger.GetLogger(ctx, server.LogOption).Error(err)
 				returnItem.Error = err.Error()
 				return
 			}
+			ctx = ctxUtils.SetContextWithNamespace(ctx, requestKey.Namespace)
 
 			if parsedReference.Digest == "" {
 				var selectedStore referrerstore.ReferrerStore

--- a/internal/context/utils.go
+++ b/internal/context/utils.go
@@ -29,6 +29,15 @@ func SetContextWithNamespace(ctx context.Context, namespace string) context.Cont
 	return context.WithValue(ctx, contextKeyNamespace, namespace)
 }
 
+// GetNamespace returns the embedded namespace from the context.
+func GetNamespace(ctx context.Context) string {
+	namespace := ctx.Value(contextKeyNamespace)
+	if namespace == nil {
+		return ""
+	}
+	return namespace.(string)
+}
+
 // CreateCacheKey creates a new cache key prefixed with embedded namespace.
 func CreateCacheKey(ctx context.Context, key string) string {
 	namespace := ctx.Value(contextKeyNamespace)

--- a/internal/context/utils_test.go
+++ b/internal/context/utils_test.go
@@ -78,3 +78,40 @@ func TestCreateCacheKey(t *testing.T) {
 		})
 	}
 }
+
+func TestGetNamespace(t *testing.T) {
+	testCases := []struct {
+		name         string
+		namespaceSet bool
+		namespace    string
+	}{
+		{
+			name:         "no namespace",
+			namespaceSet: false,
+		},
+		{
+			name:         "empty namespace",
+			namespaceSet: true,
+			namespace:    "",
+		},
+		{
+			name:         "with namespace",
+			namespaceSet: true,
+			namespace:    testNamespace,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tc.namespaceSet {
+				ctx = SetContextWithNamespace(ctx, tc.namespace)
+			}
+
+			namespace := GetNamespace(ctx)
+			if namespace != tc.namespace {
+				t.Fatalf("expected namespace %s, got %s", tc.namespace, namespace)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

## What this PR does / why we need it:
This is the first PR for multi-tenancy support.

1.  Add a `GetNamespace` util method. It fetches the namespace embeded in the context. For each request, we'll use `SetContextWithNamespace` to embed the namespace into the context, and consumers like executors, verifiers, policyEnforcers could get the namespace from the context instead of passing it through function param explicitely.
2. Embed the namespace into the context for mutation requests as well.

## Which issue(s) this PR fixes *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Helm Chart Change (any edit/addition/update that is necessary for changes merged to the `main` branch)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?

# Post Merge Requirements
- [ ] MAINTAINERS: manually trigger the "Publish Package" workflow after merging any PR that indicates `Helm Chart Change`
