### PR TITLE
fix: add akv keys check on cosign-verifier

### DIFF
--- a/charts/ratify/templates/verifier.yaml
+++ b/charts/ratify/templates/verifier.yaml
@@ -50,7 +50,7 @@ spec:
   name: cosign
   artifactTypes: application/vnd.dev.cosign.artifact.sig.v1+json
   parameters:
-    {{- if gt (len .Values.cosignKeys) 0 }}
+    {{- if or (gt (len .Values.cosignKeys) 0) (and .Values.azurekeyvault.enabled (gt (len .Values.azurekeyvault.keys) 0)) }}
     trustPolicies:
       - name: default
         version: 1.0.0

--- a/test/bats/azure-test.bats
+++ b/test/bats/azure-test.bats
@@ -58,7 +58,7 @@ SLEEP_TIME=1
     assert_success
     run kubectl apply -f ./library/default/samples/constraint.yaml
     assert_success
-   
+
     # verify that the image can be run with a root cert, root verification cert should have been configured on deployment
     run kubectl run demo-leaf --namespace default --image=${TEST_REGISTRY}/notation:leafSigned
     assert_success
@@ -110,6 +110,9 @@ SLEEP_TIME=1
     assert_success
     sleep 5
     run kubectl apply -f ./library/default/samples/constraint.yaml
+    assert_success
+    sleep 5
+    run kubectl apply -f ./test/bats/tests/config/config_v1beta1_verifier_cosign_akv.yaml
     assert_success
     sleep 5
 

--- a/test/bats/tests/config/config_v1beta1_verifier_cosign_akv.yaml
+++ b/test/bats/tests/config/config_v1beta1_verifier_cosign_akv.yaml
@@ -1,0 +1,18 @@
+apiVersion: config.ratify.deislabs.io/v1beta1
+kind: Verifier
+metadata:
+  name: verifier-cosign
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "5"
+spec:
+  name: cosign
+  artifactTypes: application/vnd.dev.cosign.artifact.sig.v1+json
+  parameters:
+    trustPolicies:
+      - name: default
+        version: 1.0.0
+        scopes:
+          - "*"
+        keys:
+          - provider: gatekeeper-system/kmprovider-akv


### PR DESCRIPTION
# Description

## What this PR does / why we need it:
AKS test is failing due to `trust policy not found` error. Root cause is we missed a check on akv keys in verifier-cosign template.

And azure-test.bats would upgrade ratify deployment which might miss the azurekeyvault.keys in the template. https://github.com/binbin-li/ratify/blob/dev/test/bats/azure-test.bats#L29

The aks test is passing on my forked branch. 
![image](https://github.com/deislabs/ratify/assets/6919333/45ac8a6b-cce5-4a39-bf09-f7f754535ed0)


## Which issue(s) this PR fixes *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Helm Chart Change (any edit/addition/update that is necessary for changes merged to the `main` branch)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?

# Post Merge Requirements
- [ ] MAINTAINERS: manually trigger the "Publish Package" workflow after merging any PR that indicates `Helm Chart Change`
