### PR TITLE
fix: handle empty trust policies

### DIFF
--- a/pkg/verifier/cosign/cosign.go
+++ b/pkg/verifier/cosign/cosign.go
@@ -146,7 +146,8 @@ func (f *cosignVerifierFactory) Create(_ string, verifierConfig config.VerifierC
 
 	var trustPolicies *TrustPolicies
 	legacy := true
-	if config.KeyRef == "" && config.RekorURL == "" {
+	// if trustPolicies are provided and non-legacy, create the trust policies
+	if config.KeyRef == "" && config.RekorURL == "" && len(config.TrustPolicies) > 0 {
 		trustPolicies, err = CreateTrustPolicies(config.TrustPolicies, verifierName)
 		if err != nil {
 			return nil, err

--- a/pkg/verifier/cosign/cosign_test.go
+++ b/pkg/verifier/cosign/cosign_test.go
@@ -88,13 +88,13 @@ func TestCreate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "invalid trust policies config",
+			name: "valid trust policies config with no legacy config or trust policies",
 			config: config.VerifierConfig{
 				"name":          "test",
 				"artifactTypes": "testtype",
 				"trustPolicies": []TrustPolicyConfig{},
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "invalid config with legacy and trust policies",


### PR DESCRIPTION
# Description

## What this PR does / why we need it:

Updates the cosign.go parameter validation logic to create a verifier even if legacy config (`key` & `rekorURL`) is not provided AND trust policies are not defined. This is particularly necessary since helm chart will by default apply cosign verifier even if keys are not provided. 

## Which issue(s) this PR fixes *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Helm Chart Change (any edit/addition/update that is necessary for changes merged to the `main` branch)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?

# Post Merge Requirements
- [ ] MAINTAINERS: manually trigger the "Publish Package" workflow after merging any PR that indicates `Helm Chart Change`
