### PR TITLE
chore: use semantic version for go install pkg

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -53,8 +53,8 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 
 # [Optional] Uncomment the next lines to use go get to install anything else you need
 USER vscode
-RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28 \
-  && go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2 \
+RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.1 \
+  && go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2.0 \
   && chmod a+w -R /go/pkg
 
 # [Optional] Uncomment this line to install global node packages.


### PR DESCRIPTION
# Description

## What this PR does / why we need it:
Fixing 2 code scanning alerts that unpinned packages were installed. Just realized that we don't follow the semantic versioning while downloading the package.

Tested on my forked repo, which works as expected.

## Which issue(s) this PR fixes *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Helm Chart Change (any edit/addition/update that is necessary for changes merged to the `main` branch)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?

# Post Merge Requirements
- [ ] MAINTAINERS: manually trigger the "Publish Package" workflow after merging any PR that indicates `Helm Chart Change`
