### PR TITLE
fix: fix AKS test by switching to cluster-wide KMP

### DIFF
--- a/charts/ratify/templates/akv-key-management-provider.yaml
+++ b/charts/ratify/templates/akv-key-management-provider.yaml
@@ -1,6 +1,6 @@
 {{- if or .Values.azurekeyvault.enabled .Values.akvCertConfig.enabled }}
 apiVersion: config.ratify.deislabs.io/v1beta1
-kind: NamespacedKeyManagementProvider
+kind: KeyManagementProvider
 metadata:
   name: kmprovider-akv
   annotations:


### PR DESCRIPTION
# Description

## What this PR does / why we need it:
AKS test is failing due to KMP not found error.
This PR updated the kind of `kmprovider-akv` from `NamespacedKeyManagementProvider` to `KeyManagementProvider` as the cluster-wide KMP is the default one.
AKS test passed on my forked repo: 

![image](https://github.com/deislabs/ratify/assets/6919333/c83baac1-1af8-4194-95ac-9d4ab2698b65)


## Which issue(s) this PR fixes *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Helm Chart Change (any edit/addition/update that is necessary for changes merged to the `main` branch)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?

# Post Merge Requirements
- [ ] MAINTAINERS: manually trigger the "Publish Package" workflow after merging any PR that indicates `Helm Chart Change`
