### PR TITLE
chore: ignore CVE-2023-42363 CVE-2023-42364 CVE-2023-42365

### DIFF
--- a/plugins/verifier/sbom/testdata/osv-scanner.toml
+++ b/plugins/verifier/sbom/testdata/osv-scanner.toml
@@ -5,3 +5,15 @@ reason = "Test manifest file(syftbom.spdx.json)"
 [[IgnoredVulns]]
 id = "CVE-2023-42366"
 reason = "Test manifest file(syftbom.spdx.json)"
+
+[[IgnoredVulns]]
+id = "CVE-2023-42363"
+reason = "Test manifest file(syftbom.spdx.json)"
+
+[[IgnoredVulns]]
+id = "CVE-2023-42364"
+reason = "Test manifest file(syftbom.spdx.json)"
+
+[[IgnoredVulns]]
+id = "CVE-2023-42365"
+reason = "Test manifest file(syftbom.spdx.json)"

--- a/plugins/verifier/schemavalidator/schemavalidation/testdata/osv-scanner.toml
+++ b/plugins/verifier/schemavalidator/schemavalidation/testdata/osv-scanner.toml
@@ -5,3 +5,15 @@ reason = "Test manifest file(trivy_scan_report.json)"
 [[IgnoredVulns]]
 id = "CVE-2023-42366"
 reason = "Test manifest file(trivy_scan_report.json)"
+
+[[IgnoredVulns]]
+id = "CVE-2023-42363"
+reason = "Test manifest file(trivy_scan_report.json)"
+
+[[IgnoredVulns]]
+id = "CVE-2023-42364"
+reason = "Test manifest file(trivy_scan_report.json)"
+
+[[IgnoredVulns]]
+id = "CVE-2023-42365"
+reason = "Test manifest file(trivy_scan_report.json)"

--- a/plugins/verifier/vulnerabilityreport/schemavalidation/testdata/osv-scanner.toml
+++ b/plugins/verifier/vulnerabilityreport/schemavalidation/testdata/osv-scanner.toml
@@ -5,3 +5,15 @@ reason = "Test manifest file(trivy_scan_report.json)"
 [[IgnoredVulns]]
 id = "CVE-2023-42366"
 reason = "Test manifest file(trivy_scan_report.json)"
+
+[[IgnoredVulns]]
+id = "CVE-2023-42363"
+reason = "Test manifest file(trivy_scan_report.json)"
+
+[[IgnoredVulns]]
+id = "CVE-2023-42364"
+reason = "Test manifest file(trivy_scan_report.json)"
+
+[[IgnoredVulns]]
+id = "CVE-2023-42365"
+reason = "Test manifest file(trivy_scan_report.json)"

--- a/test/testdata/osv-scanner.toml
+++ b/test/testdata/osv-scanner.toml
@@ -5,3 +5,15 @@ reason = "Test manifest file(trivy_scan_report.json)"
 [[IgnoredVulns]]
 id = "CVE-2023-42366"
 reason = "Test manifest file(trivy_scan_report.json)"
+
+[[IgnoredVulns]]
+id = "CVE-2023-42363"
+reason = "Test manifest file(trivy_scan_report.json)"
+
+[[IgnoredVulns]]
+id = "CVE-2023-42364"
+reason = "Test manifest file(trivy_scan_report.json)"
+
+[[IgnoredVulns]]
+id = "CVE-2023-42365"
+reason = "Test manifest file(trivy_scan_report.json)"


### PR DESCRIPTION
# Description

## What this PR does / why we need it:
Ignores the CVE-2023-42363 CVE-2023-42364 CVE-2023-42365 vulnerabilities which affect busybox. Busybox at this affected version is not functionally used by Ratify but instead exists as part of test data (sboms, vuln reports, etc). 

## Which issue(s) this PR fixes *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Helm Chart Change (any edit/addition/update that is necessary for changes merged to the `main` branch)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?

# Post Merge Requirements
- [ ] MAINTAINERS: manually trigger the "Publish Package" workflow after merging any PR that indicates `Helm Chart Change`
