### PR TITLE
fix: remove Update az cli step in aks test

### DIFF
--- a/.github/workflows/e2e-aks.yml
+++ b/.github/workflows/e2e-aks.yml
@@ -37,23 +37,6 @@ jobs:
         uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
           go-version: '1.21'
-      - name: Update az cli # TODO: remove after az cli is updated in the runnger image to be >= 2.60.0
-        run: |
-          sudo apt-get update
-          sudo apt-get install apt-transport-https ca-certificates curl gnupg lsb-release
-          sudo mkdir -p /etc/apt/keyrings
-          curl -sLS https://packages.microsoft.com/keys/microsoft.asc |
-              sudo gpg --dearmor -o /etc/apt/keyrings/microsoft.gpg
-          sudo chmod go+r /etc/apt/keyrings/microsoft.gpg
-          AZ_DIST=$(lsb_release -cs)
-          echo "Types: deb
-          URIs: https://packages.microsoft.com/repos/azure-cli/
-          Suites: ${AZ_DIST}
-          Components: main
-          Architectures: $(dpkg --print-architecture)
-          Signed-by: /etc/apt/keyrings/microsoft.gpg" | sudo tee /etc/apt/sources.list.d/azure-cli.sources
-          AZ_VER=2.60.0
-          sudo apt-get update && sudo apt-get install azure-cli
       - name: Az CLI login
         uses: azure/login@6b2456866fc08b011acb422a92a4aa20e2c4de32 # v2.1.0
         with:


### PR DESCRIPTION
# Description

## What this PR does / why we need it:
Remove `Update az cli` step in aks test since we no longer need it.

Tested on my forked repo
![image](https://github.com/deislabs/ratify/assets/6919333/5d38f40b-f356-48b1-8490-92528a586529)



## Which issue(s) this PR fixes *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Helm Chart Change (any edit/addition/update that is necessary for changes merged to the `main` branch)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?

# Post Merge Requirements
- [ ] MAINTAINERS: manually trigger the "Publish Package" workflow after merging any PR that indicates `Helm Chart Change`
