### PR TITLE
ci: switch azure ci test to use rbac for key vault access

### DIFF
--- a/.github/workflows/e2e-aks.yml
+++ b/.github/workflows/e2e-aks.yml
@@ -24,6 +24,7 @@ jobs:
       AZURE_CLIENT_ID: 814e6e97-120c-4534-b8a9-f1645bc99500
       AZURE_TENANT_ID: 72f988bf-86f1-41af-91ab-2d7cd011db47
       AZURE_SUBSCRIPTION_ID: daae1e1a-63dc-454f-825d-b39289070f79
+      AZURE_SP_OBJECT_ID: fd917b28-cdc0-4828-92c9-1ca8203842a3
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: azure-test
@@ -60,7 +61,7 @@ jobs:
 
       - name: Run e2e on Azure
         run: |
-          make e2e-aks KUBERNETES_VERSION=${{ inputs.k8s_version }} GATEKEEPER_VERSION=${{ inputs.gatekeeper_version }} TENANT_ID=${{ env.AZURE_TENANT_ID }}
+          make e2e-aks KUBERNETES_VERSION=${{ inputs.k8s_version }} GATEKEEPER_VERSION=${{ inputs.gatekeeper_version }} TENANT_ID=${{ env.AZURE_TENANT_ID }} AZURE_SP_OBJECT_ID=${{ env.AZURE_SP_OBJECT_ID }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ TEST_REGISTRY_PASSWORD = test_pw
 # Azure Key Vault Setup
 KEYVAULT_NAME ?= ratify-akv
 KEYVAULT_KEY_NAME ?= test-key
+AZURE_SP_OBJECT_ID ?= 00000000-0000-0000-0000-000000000000
 
 all: build test
 
@@ -659,7 +660,7 @@ e2e-helm-deploy-ratify-replica: e2e-helm-deploy-redis e2e-notation-setup e2e-bui
 	rm mount_config.json
 
 e2e-aks:
-	./scripts/azure-ci-test.sh ${KUBERNETES_VERSION} ${GATEKEEPER_VERSION} ${TENANT_ID} ${GATEKEEPER_NAMESPACE} ${CERT_DIR}
+	./scripts/azure-ci-test.sh ${KUBERNETES_VERSION} ${GATEKEEPER_VERSION} ${TENANT_ID} ${GATEKEEPER_NAMESPACE} ${CERT_DIR} ${AZURE_SP_OBJECT_ID}
 
 e2e-cleanup:
 	./scripts/azure-ci-test-cleanup.sh ${AZURE_SUBSCRIPTION_ID}

--- a/scripts/azure-ci-test.sh
+++ b/scripts/azure-ci-test.sh
@@ -32,6 +32,7 @@ GATEKEEPER_VERSION=${2:-3.16.0}
 TENANT_ID=$3
 export RATIFY_NAMESPACE=${4:-gatekeeper-system}
 CERT_DIR=${5:-"~/ratify/certs"}
+export AZURE_SP_OBJECT_ID=$6
 export NOTATION_PEM_NAME="notation"
 export NOTATION_CHAIN_PEM_NAME="notationchain"
 export KEYVAULT_KEY_NAME="test-key"

--- a/scripts/create-azure-resources.sh
+++ b/scripts/create-azure-resources.sh
@@ -96,11 +96,11 @@ create_akv() {
     --role "Key Vault Secrets User" \
     --scope subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${GROUP_NAME}/providers/Microsoft.KeyVault/vaults/${KEYVAULT_NAME}
   
-  # Grant permissions to access the keys
+  # Grant permissions to access/create keys
   az role assignment create \
     --assignee-object-id ${USER_ASSIGNED_IDENTITY_OBJECT_ID} \
     --assignee-principal-type "ServicePrincipal" \
-    --role "Key Vault Crypto User" \
+    --role "Key Vault Crypto Officer" \
     --scope subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${GROUP_NAME}/providers/Microsoft.KeyVault/vaults/${KEYVAULT_NAME}
 }
 

--- a/scripts/create-azure-resources.sh
+++ b/scripts/create-azure-resources.sh
@@ -90,7 +90,7 @@ create_akv() {
   echo "AKV '${KEYVAULT_NAME}' is created"
 
   # Grant permissions to access the secret
-   az role assignment create \
+  az role assignment create \
     --assignee-object-id ${USER_ASSIGNED_IDENTITY_OBJECT_ID} \
     --assignee-principal-type "ServicePrincipal" \
     --role "Key Vault Secrets User" \

--- a/scripts/create-azure-resources.sh
+++ b/scripts/create-azure-resources.sh
@@ -23,12 +23,6 @@ set -o pipefail
 : "${AKS_NAME:?AKS_NAME environment variable empty or not defined.}"
 : "${ACR_NAME:?ACR_NAME environment variable empty or not defined.}"
 
-register_feature() {
-  az extension add --name aks-preview
-  az feature register --namespace "Microsoft.ContainerService" --name "EnableWorkloadIdentityPreview"
-  az provider register --namespace Microsoft.ContainerService
-}
-
 create_user_managed_identity() {
   SUBSCRIPTION_ID="$(az account show --query id --output tsv)"
 
@@ -111,10 +105,6 @@ create_akv() {
 }
 
 main() {
-  export -f register_feature
-  # might take around 20 minutes to register
-  timeout --foreground 1200 bash -c register_feature
-
   az group create --name "${GROUP_NAME}" --tags "ratifye2e" --location "${LOCATION}" >/dev/null
 
   create_user_managed_identity

--- a/scripts/create-azure-resources.sh
+++ b/scripts/create-azure-resources.sh
@@ -103,11 +103,11 @@ create_akv() {
     --role "Key Vault Crypto User" \
     --scope subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${GROUP_NAME}/providers/Microsoft.KeyVault/vaults/${KEYVAULT_NAME}
 
-  # Grant runner SP permissions to create keys
+  # Grant runner SP permissions to create keys and import certificates
   az role assignment create \
     --assignee-object-id ${AZURE_SP_OBJECT_ID} \
     --assignee-principal-type "ServicePrincipal" \
-    --role "Key Vault Crypto Officer" \
+    --role "Key Vault Administrator" \
     --scope subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${GROUP_NAME}/providers/Microsoft.KeyVault/vaults/${KEYVAULT_NAME}
 }
 

--- a/scripts/create-azure-resources.sh
+++ b/scripts/create-azure-resources.sh
@@ -95,8 +95,19 @@ create_akv() {
 
   echo "AKV '${KEYVAULT_NAME}' is created"
 
-  # Grant permissions to access the certificate.
-  az keyvault set-policy --name ${KEYVAULT_NAME} --secret-permissions get --key-permissions get --object-id ${USER_ASSIGNED_IDENTITY_OBJECT_ID}
+  # Grant permissions to access the secret
+   az role assignment create \
+    --assignee-object-id ${USER_ASSIGNED_IDENTITY_OBJECT_ID} \
+    --assignee-principal-type "ServicePrincipal" \
+    --role "Key Vault Secrets User" \
+    --scope subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${GROUP_NAME}/providers/Microsoft.KeyVault/vaults/${KEYVAULT_NAME}
+  
+  # Grant permissions to access the keys
+  az role assignment create \
+    --assignee-object-id ${USER_ASSIGNED_IDENTITY_OBJECT_ID} \
+    --assignee-principal-type "ServicePrincipal" \
+    --role "Key Vault Crypto User" \
+    --scope subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${GROUP_NAME}/providers/Microsoft.KeyVault/vaults/${KEYVAULT_NAME}
 }
 
 main() {

--- a/scripts/create-azure-resources.sh
+++ b/scripts/create-azure-resources.sh
@@ -89,16 +89,23 @@ create_akv() {
 
   echo "AKV '${KEYVAULT_NAME}' is created"
 
-  # Grant permissions to access the secret
+  # Grant ratify identity permissions to access the secret
   az role assignment create \
     --assignee-object-id ${USER_ASSIGNED_IDENTITY_OBJECT_ID} \
     --assignee-principal-type "ServicePrincipal" \
     --role "Key Vault Secrets User" \
     --scope subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${GROUP_NAME}/providers/Microsoft.KeyVault/vaults/${KEYVAULT_NAME}
   
-  # Grant permissions to access/create keys
+  # Grant ratify identity permissions to access keys
   az role assignment create \
     --assignee-object-id ${USER_ASSIGNED_IDENTITY_OBJECT_ID} \
+    --assignee-principal-type "ServicePrincipal" \
+    --role "Key Vault Crypto User" \
+    --scope subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${GROUP_NAME}/providers/Microsoft.KeyVault/vaults/${KEYVAULT_NAME}
+
+  # Grant runner SP permissions to create keys
+  az role assignment create \
+    --assignee-object-id ${AZURE_SP_OBJECT_ID} \
     --assignee-principal-type "ServicePrincipal" \
     --role "Key Vault Crypto Officer" \
     --scope subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${GROUP_NAME}/providers/Microsoft.KeyVault/vaults/${KEYVAULT_NAME}


### PR DESCRIPTION
# Description

## What this PR does / why we need it:
- CI's currently rely on azure keyvault access policies which is now deprecated. Now, new KV by default only enable RBAC for permissions. Ratify needs to switch CI to use RBAC for secret fetch, key fetch, and key create. 
- workload identity is no longer a preview feature for AKS so preview extension is not necessary. this is now removed. 

## Which issue(s) this PR fixes *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Helm Chart Change (any edit/addition/update that is necessary for changes merged to the `main` branch)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?

# Post Merge Requirements
- [ ] MAINTAINERS: manually trigger the "Publish Package" workflow after merging any PR that indicates `Helm Chart Change`
- [ ] 