### PR TITLE
ci: add job to delete dev package versions

### DIFF
--- a/.github/workflows/clean-dev-package.yml
+++ b/.github/workflows/clean-dev-package.yml
@@ -1,0 +1,27 @@
+name: clean-dev-package
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  cleanup-packages:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clean up ratify-crds-dev
+        uses: actions/delete-package-versions@v5
+        with: 
+          package-name: 'ratify-crds-dev'
+          package-type: 'container'
+          min-versions-to-keep: 7
+          delete-only-pre-release-versions: "true"
+      - name: Clean up ratify-dev
+        uses: actions/delete-package-versions@v5
+        with: 
+          package-name: 'ratify-dev'
+          package-type: 'container'
+          min-versions-to-keep: 7
+          delete-only-pre-release-versions: "true"


### PR DESCRIPTION
# Description

## What this PR does / why we need it:
1. Add a job to delete dev package versions before releasing. It will keep the latest 7 versions which is the tagged version and its untagged multi-arch versions.
2. I made it only triggered manually. 
3. There are 2 reasons I don't add it as release step: 1) This action can delete at most 100 versions one time, so I need to run it several times to clean up all versions. 2) It's not fully tested as a stable option.

I tested on my forked repo, which keeps the latest 7 versions.
![image](https://github.com/deislabs/ratify/assets/6919333/13242517-f670-43b0-bf8b-d62b25d10685)


## Which issue(s) this PR fixes *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Helm Chart Change (any edit/addition/update that is necessary for changes merged to the `main` branch)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?

# Post Merge Requirements
- [ ] MAINTAINERS: manually trigger the "Publish Package" workflow after merging any PR that indicates `Helm Chart Change`
