### PR TITLE
chore: release v2.0.0-alpha.1

### DIFF
--- a/deployments/ratify-gatekeeper-provider/values.yaml
+++ b/deployments/ratify-gatekeeper-provider/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: "ghcr.io/notaryproject/ratify-gatekeeper-provider"
   pullPolicy: IfNotPresent
-  tag: "v2.0.0-alpha.1"
+  tag: "dev"
 
 replicaCount: 1
 


### PR DESCRIPTION
# Tag
6b583a94deebb87ab720c6e621704186232e393e as v2.0.0-alpha.1

# Draft Release Notes:
## 🚨 Breaking Changes
- **Modularization & v2 Support**: Core workflow has been decoupled into a new standalone library, [ratify-go](https://github.com/notaryproject/ratify-go), with v2 support implemented across all core modules—executor, verifier, store, and policy enforcer. [#2231](https://github.com/notaryproject/ratify/pull/2231) [#2235](https://github.com/notaryproject/ratify/pull/2235) [#2237](https://github.com/notaryproject/ratify/pull/2237) [#2238](https://github.com/notaryproject/ratify/pull/2238)
- **Key Management Changes**: The Key Management Provider has been deprecated and is now configured under the verifier section. [#2231](https://github.com/notaryproject/ratify/pull/2231)
- **Plugin Artifact Download Removed**: Verifier plugins can no longer be downloaded as artifacts. [#2231](https://github.com/notaryproject/ratify/pull/2231)
- **New HTTP Server & Entrypoint**: Introduced a v2 HTTP server with a new binary entrypoint. The v2 server is named ratify-gatekeeper-provider, replacing the v1 ratify. [#2239](https://github.com/notaryproject/ratify/pull/2239)
- **Helm Chart for v2**: Released a new Helm chart that packages the ratify-gatekeeper-provider v2 image. [#2207](https://github.com/notaryproject/ratify/pull/2207)
- **Enhanced Security Defaults**: mTLS and certificate rotation are now enabled by default. [#2242](https://github.com/notaryproject/ratify/pull/2242)

## 🐛 Bug Fixes
- **Multiple Store Config Support**: Fixed a limitation in v1 to allow configuring multiple stores with different scopes. [#2235](https://github.com/notaryproject/ratify/pull/2235)
- **Helmfile Compatibility**: Updated Helmfile templates to use .gotmpl extension, ensuring compatibility with Helmfile v1.0.0. [#2218](https://github.com/notaryproject/ratify/pull/2218)

## 📄 Documentation
- **New Helm Chart Docs**: Added a comprehensive README.md for the new Helm chart. [#2262](https://github.com/notaryproject/ratify/pull/2262)
- **v2 Development Info**: Published a Ratify v2 roadmap and development notice. [#2197](https://github.com/notaryproject/ratify/pull/2197) [#2194](https://github.com/notaryproject/ratify/pull/2194)

## ⚙️ CI/CD & Automation
- **Automated Dev Releases**: On merge to main, both the Helm chart and container image are now automatically built and published. [#2288](https://github.com/notaryproject/ratify/pull/2288)
- **Updated CI Pipelines**: Disabled v1 jobs and added new workflows for building and testing v2 on the main branch. [#2228](https://github.com/notaryproject/ratify/pull/2228) [#2221](https://github.com/notaryproject/ratify/pull/2221) [#2263](https://github.com/notaryproject/ratify/pull/2263) [#2266](https://github.com/notaryproject/ratify/pull/2266)

## 🚨 Missing Features from V1
Some key v1 features are not yet available in v2. For detailed comparisons and progress, refer to the discussion: https://github.com/notaryproject/ratify/discussions/2236
Missing features include:
- Support for additional verifiers (e.g., Cosign, SBOM, Vulnerability Report)
- Ratify server configuration via CRDs
- Cloud provider integrations (Azure, AWS, Alibaba)
- Rego policy support


# Changes:
6b583a9 chore: release v2.0.0-alpha.1
cf473a5 chore: update dev helmfile (#2289)
5e460ad ci: build and publish chart/image upon merging to main (#2288)
b82c678 chore: Bump github.com/cloudflare/circl from 1.3.7 to 1.6.1 (#2287)
cdcdbe7 chore: Bump golang from `b4f875e` to `68932fa` (#2284)
534ed8e chore: Bump github.com/aws/aws-sdk-go-v2/config from 1.29.14 to 1.29.15 (#2285)
f880db6 feat: watch file update on executor config (#2278)
134acce ci: add workflow_dispatch to build job (#2279)
1f8c318 chore: Bump github/codeql-action from 3.28.18 to 3.28.19 (#2275)
970cce3 chore: remove helmfile for HA (#2274)
01cfb1e chore: Bump ossf/scorecard-action from 2.4.1 to 2.4.2 (#2268)
79fbd24 fix: update registryScope for asset verification (#2273)
f3f8ade chore: Bump github.com/go-logr/logr from 1.4.2 to 1.4.3 (#2269)
b8e958f chore: Bump alpine from `a8560b3` to `8a1f59f` (#2270)
e09cac5 chore: Bump golang from `ef18ee7` to `b4f875e` (#2271)
2af0fd5 ci: Disable full validation for release-2. branch* (#2266)
b8b074b ci: update publish jobs (#2263)
5f8f04e docs: add readme to helm chart (#2262)
79a5cc0 chore: update ratify-project to notaryproject (#2255)
857ef8b chore: Bump github.com/google/go-containerregistry from 0.20.3 to 0.20.5 (#2253)
53598a4 build: update module to github.com/notaryproject/ratify/v2 (#2254)
a465386 feat!: add cache to server endpoint (#2252)
7293192 feat!: support mutation webhook (#2244)
1501658 chore: Bump sigs.k8s.io/controller-runtime from 0.19.1 to 0.19.7 (#2246)
35f1b01 chore: Bump k8s.io/client-go from 0.31.2 to 0.31.9 (#2247)
f9921bf chore: Bump k8s.io/api from 0.31.2 to 0.31.9 (#2248)
9aeab6e chore: Bump github.com/open-policy-agent/opa from 1.4.0 to 1.4.2 (#2249)
d862090 chore: Bump github/codeql-action from 3.28.17 to 3.28.18 (#2250)
255f58f chore: Bump distroless/static from `c0f429e` to `188ddfb` (#2251)
0e9ed01 chore: Bump codecov/codecov-action from 5.4.2 to 5.4.3 (#2243)
ae960eb feat!: support mTLS with gatekeeper and cert rotation (#2242)
d4603e0 chore: Bump anchore/sbom-action from 0.19.0 to 0.20.0 (#2241)
0bdbc35 feat!: Add v2 helm chart (#2207)
8775b5f feat!: add v2 http server (#2239)
31b21c3 feat!: add v2 executor (#2238)
e68907c feat!: add v2 policy enforcer (#2237)
c8f8e45 feat!: add v2 store (#2235)
1d13559 feat!: add v2 verifier (#2231)
4facf0d chore: Bump github.com/open-policy-agent/opa from 1.4.0 to 1.4.2 (#2232)
c71f82b chore: Bump golang from `ec5612b` to `4b1ecd8` in /httpserver (#2233)
a062dbd ci: remove labeled pull_request_target (#2234)
150f286 chore: Bump actions/setup-go from 5.4.0 to 5.5.0 (#2230)
00dd0ec ci: bump up golangci-lint version (#2229)
94973b7 chore: Bump actions/setup-go from 5.4.0 to 5.5.0 (#2220)
e319efd ci: add CIs running on main branch (#2228)
d7ecf50 chore: remove .vscode folder (#2227)
15f0165 chore: reorganize project structure (#2226)
553ee02 ci: stop running full validation on main branch (#2221)
8d01234 fix: add .gotmpl file extension for go template (#2218)
652d59f chore: Bump github.com/open-policy-agent/opa from 0.68.0 to 1.4.0 (#2219)
230b2a0 chore: Bump golang from `e54daaa` to `ec5612b` in /httpserver (#2216)
aba2d9f chore: Bump github/codeql-action from 3.28.16 to 3.28.17 (#2214)
8e266c6 chore: Bump oras-project/setup-oras from 1.2.2 to 1.2.3 (#2213)
71ab65f chore: Bump github.com/notaryproject/notation-go from 1.3.1 to 1.3.2 (#2208)
42756c3 chore: Bump github.com/aliyun/credentials-go from 1.4.5 to 1.4.6 (#2209)
62148ab chore: Bump github.com/sigstore/sigstore from 1.9.3 to 1.9.4 (#2210)
b2f2a15 chore: Bump golang from `4f3bd60` to `e54daaa` in /httpserver (#2211)
f89c812 chore: Bump anchore/sbom-action from 0.18.0 to 0.19.0 (#2206)
1fa388e chore: Bump github/codeql-action from 3.28.15 to 3.28.16 (#2205)
3696806 chore: Bump step-security/harden-runner from 2.11.1 to 2.12.0 (#2203)
7ca8c48 chore: Bump sigstore/cosign-installer from 3.8.1 to 3.8.2 (#2204)
611b2a8 chore: Bump google.golang.org/grpc from 1.71.0 to 1.71.1 (#2198)
52279a0 chore: Bump github.com/aws/aws-sdk-go-v2/config from 1.29.10 to 1.29.14 (#2200)
3aaa44b chore: Bump github.com/sigstore/sigstore from 1.9.1 to 1.9.3 (#2201)
4a31c54 chore: Bump github.com/alibabacloud-go/darabonba-openapi/v2 from 2.0.10 to 2.0.11 (#2202)
6b20703 docs: add v2 roadmap (#2197)
fcdd325 chore: Bump golang.org/x/net from 0.37.0 to 0.38.0 (#2196)
4a22e3b build!: init ratify v2 (#2195)
013007e docs: add v2 development notice (#2194)
2a9cbc2 chore: Bump codecov/codecov-action from 5.4.0 to 5.4.2 (#2193)
c2b600e chore: Bump golang from `cb45cf7` to `4f3bd60` in /httpserver (#2185)
52c8425 chore: Bump github.com/sigstore/rekor from 1.3.9 to 1.3.10 (#2189)
f8119fb chore: Bump github.com/aws/aws-sdk-go-v2/credentials from 1.17.66 to 1.17.67 (#2190)
21a04ac chore: Bump github.com/aws/aws-sdk-go-v2/credentials from 1.17.65 to 1.17.66 (#2186)
c60d70b fix: fix broken pipelines after switching default branch to main (#2187)
014dd41 Merge pull request #2180 from ratify-project/dev
2978dbc chore: Bump github/codeql-action from 3.28.13 to 3.28.15 (#2183)
4ac1daa chore: Bump golangci/golangci-lint-action from 6.5.2 to 7.0.0 (#2179)
c502a59 chore: Bump step-security/harden-runner from 2.11.0 to 2.11.1 (#2177)
faad0a8 chore: Bump github.com/aws/aws-sdk-go-v2/credentials from 1.17.62 to 1.17.65 (#2171)
89fcb70 chore: Bump google.golang.org/protobuf from 1.36.5 to 1.36.6 (#2170)
07e32cb chore: Bump distroless/static from `b35229a` to `c0f429e` in /httpserver (#2172)
9820e8f chore: Bump goreleaser/goreleaser-action from 6.2.1 to 6.3.0 (#2169)
b9022bf Merge pull request #2167 from ratify-project/dev
f40d736 chore: update public certs for verification (#2168)
af82b23 docs: update meeting inforamtion in README (#2166)
d9e6360 chore: Bump github/codeql-action from 3.28.12 to 3.28.13 (#2164)
0f0d189 chore: Bump vscode/devcontainers/go from `5625272` to `f2d2a2b` in /.devcontainer (#2163)
e8d5fe5 chore: Bump golang from `dd1a8cb` to `cb45cf7` in /httpserver (#2162)
76c5b7e chore: Bump github.com/Azure/azure-sdk-for-go/sdk/azcore from 1.17.0 to 1.17.1 (#2161)
49b13a6 Merge pull request #2160 from ratify-project/dev
49b664d chore: Bump github.com/golang-jwt/jwt/v4 from 4.5.1 to 4.5.2 (#2159)
0976450 chore: Bump github.com/golang-jwt/jwt/v5 from 5.2.1 to 5.2.2 (#2158)
1ff8787 chore: Bump actions/upload-artifact from 4.6.1 to 4.6.2 (#2156)
69a7263 chore: Bump actions/cache from 4.2.2 to 4.2.3 (#2155)
0fbef6f chore: Bump github/codeql-action from 3.28.11 to 3.28.12 (#2154)
32fe732 chore: Bump actions/setup-go from 5.3.0 to 5.4.0 (#2153)
41ce80e Merge pull request #2148 from ratify-project/dev
8f63552 chore: Bump golangci/golangci-lint-action from 6.5.1 to 6.5.2 (#2152)
dfc1c67 chore: Bump docker/login-action from 3.3.0 to 3.4.0 (#2151)
b6fbad5 chore: Bump distroless/static from `6ec5aa9` to `b35229a` in /httpserver (#2150)
64f0638 chore: Bump golang from `1acb493` to `dd1a8cb` in /httpserver (#2149)
0aae82b chore: Bump golangci/golangci-lint-action from 6.5.0 to 6.5.1 (#2147)
76e2257 chore: Bump golang.org/x/net from 0.35.0 to 0.36.0 (#2146)
086d097 chore: Bump github/codeql-action from 3.28.10 to 3.28.11 (#2144)
90252bd chore: Bump golang from `adfbe17` to `1acb493` in /httpserver (#2143)
3de0375 chore: Bump github.com/opencontainers/image-spec from 1.1.0 to 1.1.1 (#2142)
be7a733 chore: Bump github.com/aws/aws-sdk-go-v2/credentials from 1.17.61 to 1.17.62 (#2141)
eda5139 Merge pull request #2137 from ratify-project/dev
7de6968 chore: Bump github.com/aws/aws-sdk-go-v2/credentials from 1.17.60 to 1.17.61 (#2139)
fd7854d chore: Bump golang from `77a21b3` to `adfbe17` in /httpserver (#2140)
9d0c8bd chore: Bump actions/cache from 4.2.1 to 4.2.2 (#2136)
2819c6b chore: Bump codecov/codecov-action from 5.3.1 to 5.4.0 (#2135)
007bb9e Merge pull request #2123 from ratify-project/dev
513ffa0 chore: Bump github.com/go-jose/go-jose/v3 from 3.0.3 to 3.0.4 (#2134)
c093972 chore: Bump nick-fields/retry from 3.0.1 to 3.0.2 (#2133)
d747ad1 chore: Bump github.com/go-jose/go-jose/v4 from 4.0.2 to 4.0.5 (#2132)
1306c25 chore: Bump actions/upload-artifact from 4.6.0 to 4.6.1 (#2130)
7b4c1c2 chore: Bump github/codeql-action from 3.28.9 to 3.28.10 (#2129)
3f2a0cb chore: Bump ossf/scorecard-action from 2.4.0 to 2.4.1 (#2128)
617c5b8 chore: Bump notaryproject/notation-action from 1.2.1 to 1.2.2 (#2127)
8f50d97 chore: Bump github.com/notaryproject/notation-go from 1.3.0 to 1.3.1 (#2125)
b33c108 chore: Bump github.com/aws/aws-sdk-go-v2/credentials from 1.17.59 to 1.17.60 (#2126)
8d01fd6 docs: add Ratify Enhancement Proposal Template (#2120)
661751a chore: Bump sigstore/cosign-installer from 3.8.0 to 3.8.1 (#2122)
099af84 chore: Bump apache/skywalking-eyes from 0.6.0 to 0.7.0 (#2102)
58e706a chore: Bump github.com/sigstore/sigstore from 1.8.12 to 1.8.15 (#2119)
5938a56 chore: Bump github.com/Azure/azure-sdk-for-go/sdk/azidentity from 1.8.1 to 1.8.2 (#2112)
4c9956a chore: Bump alpine from `56fa17d` to `a8560b3` (#2113)
6c66115 chore: Bump nick-fields/retry from 3.0.0 to 3.0.1 (#2117)
e709ca3 chore: Bump golang from `9271129` to `77a21b3` in /httpserver (#2116)
7a79ba1 chore: Bump golangci/golangci-lint-action from 6.3.2 to 6.5.0 (#2114)
e5d3a6e chore: Bump step-security/harden-runner from 2.10.4 to 2.11.0 (#2115)
af0e1bd Merge pull request #2110 from ratify-project/dev
d69c81f chore: bump github actions cache to latest version (#2118)
566d220 chore: Bump golangci/golangci-lint-action from 6.3.1 to 6.3.2 (#2107)
85c6cc4 chore: Bump goreleaser/goreleaser-action from 6.1.0 to 6.2.1 (#2106)
9120760 chore: Bump github.com/aws/aws-sdk-go-v2/credentials from 1.17.57 to 1.17.59 (#2103)
b2afe90 chore: Bump google.golang.org/protobuf from 1.36.4 to 1.36.5 (#2104)
8b9ec03 chore: Bump github/codeql-action from 3.28.8 to 3.28.9 (#2101)
a3f536d chore: Bump golangci/golangci-lint-action from 6.3.0 to 6.3.1 (#2100)
7b67171 chore: Bump golang from `8c10f21` to `9271129` in /httpserver (#2099)
e420a08 Merge pull request #2088 from ratify-project/dev
2ee23a3 chore: Bump golangci/golangci-lint-action from 6.2.0 to 6.3.0 (#2095)
6344a15 chore: Bump sigstore/cosign-installer from 3.7.0 to 3.8.0 (#2096)
4ebb248 fix: update Azure authentication utility method to provide correct authority host (#2097)
12aa045 chore: update dev chart (#2094)
fb5b227 chore: upgrade CRL revocation factory interface (#2028)
15d0b79 chore: Bump github.com/sigstore/rekor from 1.3.8 to 1.3.9 (#2093)
c7d3e0e chore: Bump github.com/aws/aws-sdk-go-v2/credentials from 1.17.55 to 1.17.57 (#2092)
7dde730 chore: Bump google.golang.org/protobuf from 1.36.3 to 1.36.4 (#2091)
50a590e chore: Bump github.com/docker/cli from 27.5.0+incompatible to 27.5.1+incompatible (#2090)
71305cf chore: Bump github.com/AzureAD/microsoft-authentication-library-for-go from 1.3.2 to 1.3.3 (#2089)
38b2e7f chore: Bump github/codeql-action from 3.28.5 to 3.28.8 (#2086)
9e4c5e2 chore: bump ristretto pkg version (#2085)
6af40d8 chore: Bump anchore/sbom-action from 0.17.9 to 0.18.0 (#2067)
5988e88 chore: Bump github.com/sigstore/rekor from 1.3.7 to 1.3.8 (#2074)
42f30ea chore: Bump github.com/aws/aws-sdk-go-v2/credentials from 1.17.54 to 1.17.55 (#2073)
ec7fed2 chore: Bump github.com/google/go-containerregistry from 0.20.2 to 0.20.3 (#2075)
5bd5509 chore: Bump codecov/codecov-action from 5.3.0 to 5.3.1 (#2076)
69e3961 chore: Bump github/codeql-action from 3.28.4 to 3.28.5 (#2077)
2e8e488 chore: Bump golang from `51a6466` to `8c10f21` in /httpserver (#2078)
8f3965f chore: add more acr endpoints (#2079)
b6ad5d8 fix: enforce host checking before exchanging a refresh token (#2069)
d37ab24 chore: Bump github/codeql-action from 3.28.3 to 3.28.4 (#2066)
4b804b8 chore: Bump codecov/codecov-action from 5.1.2 to 5.3.0 (#2065)
5a25813 chore: Bump notaryproject/notation-action from 1.2.0 to 1.2.1 (#2063)
78d8128 fix: remove default prefix from trustedIdentities default template (#2057)
456b9af chore: Bump github/codeql-action from 3.28.2 to 3.28.3 (#2062)
6fc5514 docs: add ratify v2 architecture design proposal (#1962)
a74841f docs: add Ratify v2 design scope discussion (#1905)
7794266 chore: Bump oras-project/setup-oras from 1.2.1 to 1.2.2 (#2059)
5436c19 chore: Bump github/codeql-action from 3.28.1 to 3.28.2 (#2058)
2291ea3 docs: remove Microsoft trademark (#2036)
1cac024 chore: Bump actions/setup-go from 5.2.0 to 5.3.0 (#2053)
4553c9f chore: Bump gaurav-nelson/github-action-markdown-link-check from 1.0.15 to 1.0.16 (#2052)
c3cc609 chore: meeting notes ratify-weekly-notes-2024-Jun-2024-Dec.md (#2048)
d0eb4ff chore: Bump github.com/aws/aws-sdk-go-v2/config from 1.28.10 to 1.28.11 (#2043)
50d0a43 chore: update logs for migrate CertStore to KMP (#2039)
643201c chore: Bump github.com/Azure/azure-sdk-for-go/sdk/azidentity from 1.8.0 to 1.8.1 (#2042)
5e29add chore: Bump github.com/aws/aws-sdk-go-v2/credentials from 1.17.51 to 1.17.54 (#2044)
e2a4f8e chore: Bump github.com/notaryproject/notation-go from 1.3.0-rc.2 to 1.3.0 (#2045)
a8d293a chore: Bump step-security/harden-runner from 2.10.3 to 2.10.4 (#2046)
2bc3bc9 chore: Bump golang from `7ea4c9d` to `51a6466` in /httpserver (#2047)
bb1a286 Merge pull request #2038 from ratify-project/dev
59b81d1 docs: update dead link (#2040)
6005ff8 chore: Bump golangci/golangci-lint-action from 6.1.1 to 6.2.0 (#2037)
9651896 chore: Bump github.com/aws/aws-sdk-go-v2/config from 1.28.7 to 1.28.10 (#2022)
88434f7 chore: Bump github.com/aws/aws-sdk-go-v2 from 1.32.7 to 1.32.8 (#2021)
03dd8d6 chore: Bump github.com/aws/aws-sdk-go-v2/credentials from 1.17.48 to 1.17.51 (#2020)
7d6ad28 chore: Bump step-security/harden-runner from 2.10.2 to 2.10.3 (#2016)
07001d2 chore: Bump actions/upload-artifact from 4.5.0 to 4.6.0 (#2015)
3f9ae30 ci: suppress false-positive CVE in CRD image scanner (#2033)
37b65e2 chore: update markdown link (#2030)
d3ec4f4 feat: add nversion support to azurekeyvault provider certificates and keys (#1955)
ccc3c3f chore: update charts 1.4.0-rc.1 (#2029)
680cbbb chore: Bump github.com/sigstore/sigstore from 1.8.11 to 1.8.12 (#2023)
3319ebc chore: Bump distroless/static from `6cd937e` to `6ec5aa9` in /httpserver (#2024)
a39adc0 chore: Bump github/codeql-action from 3.28.0 to 3.28.1 (#2026)
ef97042 Merge pull request #2019 from ratify-project/dev
c6b0b6f chore: Bump alpine from `21dc606` to `56fa17d` (#2018)
c96705d docs: add alibaba cloud ACK into adopters (#2012)
8fa7c3e fix: update configmap (#2014)


Diff: [v1.4.0...6b583a94deebb87ab720c6e621704186232e393e](https://github.com/notaryproject/ratify/compare/v1.4.0...notaryproject:ratify:6b583a94deebb87ab720c6e621704186232e393e)
# Votes
- [x] @akashsinghal 
- [x] @binbin-li 
- [ ] @jimmyraywv 
- [ ] @luisdlp 
- [x] @susanshi 
- [ ] @toddysm 