### PR TITLE
Use default AWS creds chain to support EKS Pod Identity

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/alibabacloud-go/tea v1.2.2
 	github.com/alibabacloud-go/tea-utils/v2 v2.0.7
 	github.com/aliyun/credentials-go v1.3.11
-	github.com/aws/aws-sdk-go-v2 v1.36.3
+	github.com/aws/aws-sdk-go-v2 v1.39.2
 	github.com/aws/aws-sdk-go-v2/config v1.29.10
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.66
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.28.6
@@ -155,7 +155,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.25.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.18 // indirect
-	github.com/aws/smithy-go v1.22.2 // indirect
+	github.com/aws/smithy-go v1.23.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/bshuster-repo/logrus-logstash-hook v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -168,8 +168,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3d
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aws/aws-sdk-go v1.55.6 h1:cSg4pvZ3m8dgYcgqB97MrcdjUmZ1BeMYKUxMMB89IPk=
 github.com/aws/aws-sdk-go v1.55.6/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
-github.com/aws/aws-sdk-go-v2 v1.36.3 h1:mJoei2CxPutQVxaATCzDUjcZEjVRdpsiiXi2o38yqWM=
-github.com/aws/aws-sdk-go-v2 v1.36.3/go.mod h1:LLXuLpgzEbD766Z5ECcRmi8AzSwfZItDtmABVkRLGzg=
+github.com/aws/aws-sdk-go-v2 v1.39.2 h1:EJLg8IdbzgeD7xgvZ+I8M1e0fL0ptn/M47lianzth0I=
+github.com/aws/aws-sdk-go-v2 v1.39.2/go.mod h1:sDioUELIUO9Znk23YVmIk86/9DOpkbyyVb1i/gUNFXY=
 github.com/aws/aws-sdk-go-v2/config v1.29.10 h1:yNjgjiGBp4GgaJrGythyBXg2wAs+Im9fSWIUwvi1CAc=
 github.com/aws/aws-sdk-go-v2/config v1.29.10/go.mod h1:A0mbLXSdtob/2t59n1X0iMkPQ5d+YzYZB4rwu7SZ7aA=
 github.com/aws/aws-sdk-go-v2/credentials v1.17.66 h1:aKpEKaTy6n4CEJeYI1MNj97oSDLi4xro3UzQfwf5RWE=
@@ -198,8 +198,8 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.1 h1:hXmVKytPfTy5axZ+fYbR5d0c
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.1/go.mod h1:MlYRNmYu/fGPoxBQVvBYr9nyr948aY/WLUvwBMBJubs=
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.18 h1:xz7WvTMfSStb9Y8NpCT82FXLNC3QasqBfuAFHY4Pk5g=
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.18/go.mod h1:cQnB8CUnxbMU82JvlqjKR2HBOm3fe9pWorWBza6MBJ4=
-github.com/aws/smithy-go v1.22.2 h1:6D9hW43xKFrRx/tXXfAlIZc4JI+yQe6snnWcQyxSyLQ=
-github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
+github.com/aws/smithy-go v1.23.0 h1:8n6I3gXzWJB2DxBDnfxgBaSX6oe0d/t10qGz7OKqMCE=
+github.com/aws/smithy-go v1.23.0/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
 github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20231024185945-8841054dbdb8 h1:SoFYaT9UyGkR0+nogNyD/Lj+bsixB+SNuAS4ABlEs6M=
 github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20231024185945-8841054dbdb8/go.mod h1:2JF49jcDOrLStIXN/j/K1EKRq8a8R2qRnlZA6/o/c7c=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/pkg/common/oras/authprovider/aws/awsecrbasic_test.go
+++ b/pkg/common/oras/authprovider/aws/awsecrbasic_test.go
@@ -18,7 +18,6 @@ package aws
 import (
 	"context"
 	"encoding/base64"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -110,9 +109,8 @@ func TestAwsEcrBasicAuthProvider_ProvidesWithHost(t *testing.T) {
 func TestAwsEcrBasicAuthProvider_GetAuthTokenWithoutRegion(t *testing.T) {
 	authProvider := mockAuthProvider()
 
-	os.Setenv("AWS_REGION", "placeholder")
-	os.Setenv("AWS_ROLE_ARN", "placeholder")
-	os.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", "placeholder")
+	// Note: AWS_REGION is optional now - will be derived from registry if not set
+	// This test verifies that artifacts without region information fail appropriately
 	_, err := authProvider.getEcrAuthToken(testArtifactWithoutRegion)
 	if err == nil {
 		t.Fatalf("expected error: %+v", err)


### PR DESCRIPTION
## Description

Use default AWS credentials chain to support EKS Pod Identity.

Currently the AWS authentication is hard-coded to support IRSA only by checking for injected env variables `AWS_WEB_IDENTITY_TOKEN_FILE` and `AWS_ROLE_ARN`.

These changes use the default AWS credentials chain which also supports EKS Pod Identity (which inject env variable `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` instead).

Pod Identity is a simpler approach in EKS than IRSA since OIDC identity providers are not needed, see [here](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html).

### Which issue(s) does this PR resolve?

n/a

### Type of change

<!-- Please delete options that are not relevant. -->

- New feature (non-breaking change which adds functionality)

## Testing and verification

Related unit test passes:
```
go test -v -run TestAwsEcrBasicAuthProvider ./pkg/common/oras/authprovider/aws/

=== RUN   TestAwsEcrBasicAuthProvider_Create
--- PASS: TestAwsEcrBasicAuthProvider_Create (0.00s)
=== RUN   TestAwsEcrBasicAuthProvider_Enabled
time="2025-10-14T14:43:29+01:00" level=error msg="basic ECR providerName was empty"
--- PASS: TestAwsEcrBasicAuthProvider_Enabled (0.00s)
=== RUN   TestAwsEcrBasicAuthProvider_ProvidesWithArtifact
--- PASS: TestAwsEcrBasicAuthProvider_ProvidesWithArtifact (0.00s)
=== RUN   TestAwsEcrBasicAuthProvider_ProvidesWithHost
--- PASS: TestAwsEcrBasicAuthProvider_ProvidesWithHost (0.00s)
=== RUN   TestAwsEcrBasicAuthProvider_GetAuthTokenWithoutRegion
--- PASS: TestAwsEcrBasicAuthProvider_GetAuthTokenWithoutRegion (0.00s)
PASS
ok  	github.com/ratify-project/ratify/pkg/common/oras/authprovider/aws	(cached)
```

We've also build and tested this patch in our environment which now enables Ratify to use EKS Pod Identity rather the IRSA to authenticate to our ECR repo.

## Checklist

- [x] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?

## Post merge requirements

- [ ] MAINTAINERS: manually trigger the "Publish Package" workflow after merging any PR that indicates `Helm Chart Change`
