### PR TITLE
ci: verify container image exists before publishing helm chart

### DIFF
--- a/.github/workflows/publish-charts.yml
+++ b/.github/workflows/publish-charts.yml
@@ -18,6 +18,24 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - name: Verify container image exists
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          ORG_NAME=$(echo "$GITHUB_REPOSITORY" | cut -d'/' -f1)
+          IMAGE="ghcr.io/${ORG_NAME}/ratify-gatekeeper-provider:${VERSION}"
+          echo "Checking if image exists: ${IMAGE}"
+          MAX_RETRIES=30
+          RETRY_INTERVAL=60
+          for i in $(seq 1 $MAX_RETRIES); do
+            if docker buildx imagetools inspect "${IMAGE}" > /dev/null 2>&1; then
+              echo "Image ${IMAGE} found!"
+              exit 0
+            fi
+            echo "Attempt ${i}/${MAX_RETRIES}: Image not found yet, retrying in ${RETRY_INTERVAL}s..."
+            sleep $RETRY_INTERVAL
+          done
+          echo "ERROR: Image ${IMAGE} not found after ${MAX_RETRIES} attempts"
+          exit 1
       - name: Publish Helm charts
         uses: stefanprodan/helm-gh-pages@0ad2bb377311d61ac04ad9eb6f252fb68e207260 # v1.7.0
         with:

--- a/.github/workflows/publish-dev-assets.yml
+++ b/.github/workflows/publish-dev-assets.yml
@@ -120,13 +120,25 @@ jobs:
             "${{ steps.prepare.outputs.baseref }}:${{ steps.prepare.outputs.version }}"
             "${{ steps.prepare.outputs.ref }}:${{ steps.prepare.outputs.version }}"
           )
+          MAX_ATTEMPTS=5
+          BASE_SLEEP_SECONDS=5
           for IMAGE in "${IMAGES[@]}"; do
             echo "Checking if image exists: ${IMAGE}"
-            if ! docker buildx imagetools inspect "${IMAGE}" > /dev/null 2>&1; then
-              echo "ERROR: Image ${IMAGE} not found!"
-              exit 1
-            fi
-            echo "Image ${IMAGE} found!"
+            for ATTEMPT in $(seq 1 "${MAX_ATTEMPTS}"); do
+              if docker buildx imagetools inspect "${IMAGE}" > /dev/null 2>&1; then
+                echo "Image ${IMAGE} found!"
+                break
+              fi
+
+              if [ "${ATTEMPT}" -eq "${MAX_ATTEMPTS}" ]; then
+                echo "ERROR: Image ${IMAGE} not found after ${MAX_ATTEMPTS} attempts!"
+                exit 1
+              fi
+
+              SLEEP_SECONDS=$((BASE_SLEEP_SECONDS * ATTEMPT))
+              echo "Image ${IMAGE} not available yet (attempt ${ATTEMPT}/${MAX_ATTEMPTS}); retrying in ${SLEEP_SECONDS}s..."
+              sleep "${SLEEP_SECONDS}"
+            done
           done
       - name: helm package
         run: |

--- a/.github/workflows/publish-dev-assets.yml
+++ b/.github/workflows/publish-dev-assets.yml
@@ -113,6 +113,21 @@ jobs:
           sed -i '/^  repository:/c\  repository: ghcr.io/ratify-project/ratify-dev' charts/ratify/values.yaml
           sed -i '/^  crdRepository:/c\  crdRepository: ghcr.io/ratify-project/ratify-crds-dev' charts/ratify/values.yaml
           sed -i '/^  tag:/c\  tag: ${{ steps.prepare.outputs.version }}' charts/ratify/values.yaml
+      - name: Verify container images exist
+        run: |
+          IMAGES=(
+            "${{ steps.prepare.outputs.crdref }}:${{ steps.prepare.outputs.version }}"
+            "${{ steps.prepare.outputs.baseref }}:${{ steps.prepare.outputs.version }}"
+            "${{ steps.prepare.outputs.ref }}:${{ steps.prepare.outputs.version }}"
+          )
+          for IMAGE in "${IMAGES[@]}"; do
+            echo "Checking if image exists: ${IMAGE}"
+            if ! docker buildx imagetools inspect "${IMAGE}" > /dev/null 2>&1; then
+              echo "ERROR: Image ${IMAGE} not found!"
+              exit 1
+            fi
+            echo "Image ${IMAGE} found!"
+          done
       - name: helm package
         run: |
           helm package ./charts/ratify --version ${{ steps.prepare.outputs.semversion }}


### PR DESCRIPTION
## Description

`publish-charts.yml` and `publish-package.yml` are both triggered by `v*` tags but run as independent workflows. This creates a race condition where the helm chart could be published before the container image is available on GHCR.

This PR adds an image existence check:

- **`publish-charts.yml`**: Adds a retry loop (up to 30 min) that waits for `ghcr.io/<org>/ratify-gatekeeper-provider:<version>` to be available before publishing the chart.
- **`publish-dev-assets.yml`**: Adds a verification step between the image build and `helm push` to confirm all images (`crds`, `base`, `plugins`) are accessible before packaging and pushing the chart.

## Why

If a user installs the chart immediately after a release, they could hit `ImagePullBackOff` because the image hasn't finished building/pushing yet. This ensures the chart is only published after the image is confirmed available.

## Changes

- `.github/workflows/publish-charts.yml`: Added `Verify container image exists` step with retry logic
- `.github/workflows/publish-dev-assets.yml`: Added `Verify container images exist` step before `helm package`
