### PR TITLE
fix: add emptyDir for ORAS local cache to support nonroot image builds

### DIFF
--- a/charts/ratify/templates/deployment.yaml
+++ b/charts/ratify/templates/deployment.yaml
@@ -111,6 +111,8 @@ spec:
               name: client-ca-cert
               readOnly: true
             {{- end }}
+            - mountPath: /.ratify
+              name: ratify-cache
           env:
           {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
@@ -181,6 +183,8 @@ spec:
               - key: ca.crt
                 path: ca.crt
         {{- end }}
+        - name: ratify-cache
+          emptyDir: {}
       affinity:
         {{- toYaml .Values.affinity | nindent 8 }}
       tolerations:

--- a/charts/ratify/templates/deployment.yaml
+++ b/charts/ratify/templates/deployment.yaml
@@ -111,7 +111,7 @@ spec:
               name: client-ca-cert
               readOnly: true
             {{- end }}
-            - mountPath: /.ratify
+            - mountPath: /.ratify/local_oras_cache
               name: ratify-cache
           env:
           {{- with .Values.env }}


### PR DESCRIPTION
## Description

The Ratify container runs as nonroot (uid 65532). At runtime, the ORAS referrer store needs to create a local cache directory at `$HOME/.ratify/local_oras_cache/`.

In the upstream Dockerfile, `/.ratify/` is implicitly created and owned by uid 65532 as a side effect of `COPY --chown=65532:65532 ... /.ratify/plugins`. However, alternative image builds (e.g. Dalec/Azure Linux distroless) that install plugins to standard system paths (`/usr/bin/`) do not create this directory. Since `/` is owned by root, the nonroot user cannot `mkdir /.ratify`, causing ORAS store initialization to fail:

```
mkdir /.ratify: permission denied
```

This results in **all image verification requests being rejected**, regardless of signature status.

### Fix

Add an `emptyDir` volume mounted at `/.ratify/local_oras_cache` to provide a writable cache directory without overwriting the existing `/.ratify/` contents (plugins, config) in upstream images.

### Which issue(s) does this PR resolve?

Fixes ORAS store initialization failure for nonroot image builds that do not pre-create `/.ratify/`.

### Type of change

- Bug fix (non-breaking change which fixes an issue)
- Helm chart change

## Testing and verification

Verified on AKS cluster with Gatekeeper + Ratify (Dalec-built image `upstream.azurecr.io/oss/v2/notaryproject/ratify:v1.4.1-1`):

1. **Without emptyDir**: ORAS store fails with `mkdir /.ratify: permission denied` → all images rejected
2. **With emptyDir at `/.ratify`**: Works but **overwrites** baked-in `/.ratify/plugins/` → plugin verifiers broken
3. **With emptyDir at `/.ratify/local_oras_cache`**: ORAS cache writable, plugins preserved ✅

```bash
# Signed image — accepted
$ kubectl run demo --image=ghcr.io/deislabs/ratify/notary-image:signed
pod/demo created

# Unsigned image — denied
$ kubectl run demo2 --image=ghcr.io/deislabs/ratify/notary-image:unsigned
Error from server (Forbidden): admission webhook "validation.gatekeeper.sh" denied the request
```

## Checklist

- [x] Does the affected code have corresponding tests?
- [x] Are the changes documented?
- [x] Does this introduce breaking changes? **No**
- [x] Do all new files have appropriate license header? N/A (template change only)
