### PR TITLE
chore: publish Helm chart only after image publish succeeds

### DIFF
--- a/.github/workflows/publish-charts.yml
+++ b/.github/workflows/publish-charts.yml
@@ -1,13 +1,15 @@
 name: publishChart
 on:
-  push:
-    tags:
-      - v*
+  workflow_run:
+    workflows: ["publish-ghcr"]
+    types: [completed]
+  workflow_dispatch:
 
 permissions: read-all
 
 jobs:
   release:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -18,6 +20,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
       - name: Publish Helm charts
         uses: stefanprodan/helm-gh-pages@0ad2bb377311d61ac04ad9eb6f252fb68e207260 # v1.7.0
         with:


### PR DESCRIPTION
## What this PR does

Changes `publish-charts.yml` to trigger via `workflow_run` instead of `push tags`, so the Helm chart is published **only after** the `publish-ghcr` image workflow completes successfully.

## Why

Previously both workflows triggered independently on tag push. If the image build/push failed or was still running, the chart could be published referencing images that don't exist yet.

## Changes

- **Trigger**: `push tags: v*` → `workflow_run: publish-ghcr (completed)`
- **Guard**: `if: github.event.workflow_run.conclusion == 'success'` — chart only publishes when images succeed
- **Checkout ref**: uses `workflow_run.head_branch` to check out the correct tag
- **Manual fallback**: keeps `workflow_dispatch` for manual runs

## Testing

This is a CI-only change. Can be verified on the next tag push.