### PR TITLE
fix: use tenant authority for azure workload identity

### DIFF
--- a/.github/crd.trivyignore.yaml
+++ b/.github/crd.trivyignore.yaml
@@ -5,6 +5,12 @@ vulnerabilities:
     statement: Go stdlib CVE fixed in 1.26.3; kubectl 1.36.1 compiled with Go 1.26.2; waiting for k8s patch release with Go 1.26.3+
   - id: CVE-2026-33814
     statement: Go stdlib CVE fixed in 1.26.3; kubectl 1.36.1 compiled with Go 1.26.2; waiting for k8s patch release with Go 1.26.3+
+  - id: CVE-2026-39823
+    statement: Go stdlib CVE fixed in 1.26.3; kubectl 1.36.1 compiled with Go 1.26.2; waiting for k8s patch release with Go 1.26.3+
+  - id: CVE-2026-39825
+    statement: Go stdlib CVE fixed in 1.26.3; kubectl 1.36.1 compiled with Go 1.26.2; waiting for k8s patch release with Go 1.26.3+
+  - id: CVE-2026-39826
+    statement: Go stdlib CVE fixed in 1.26.3; kubectl 1.36.1 compiled with Go 1.26.2; waiting for k8s patch release with Go 1.26.3+
   - id: CVE-2026-39820
     statement: Go stdlib CVE fixed in 1.26.3; kubectl 1.36.1 compiled with Go 1.26.2; waiting for k8s patch release with Go 1.26.3+
   - id: CVE-2026-39836

--- a/pkg/utils/azureauth/authenticationUtils.go
+++ b/pkg/utils/azureauth/authenticationUtils.go
@@ -18,8 +18,8 @@ package azureauth
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/confidential"
@@ -66,7 +66,8 @@ func GetAADAccessToken(ctx context.Context, tenantID, clientID, scope string) (c
 }
 
 func getAuthority(authorityHost, tenantID string) string {
-	return fmt.Sprintf("%s/%s", strings.TrimRight(authorityHost, "/"), tenantID)
+	authority, _ := url.JoinPath(authorityHost, tenantID)
+	return authority
 }
 
 // readJWTFromFS reads the jwt from file system

--- a/pkg/utils/azureauth/authenticationUtils.go
+++ b/pkg/utils/azureauth/authenticationUtils.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/confidential"
@@ -49,7 +50,7 @@ func GetAADAccessToken(ctx context.Context, tenantID, clientID, scope string) (c
 
 	// create the confidential client to request an AAD token
 	confidentialClientApp, err := confidential.New(
-		fmt.Sprintf("%s%s/oauth2/token", authority, tenantID),
+		getAuthority(authority, tenantID),
 		clientID,
 		cred)
 	if err != nil {
@@ -62,6 +63,10 @@ func GetAADAccessToken(ctx context.Context, tenantID, clientID, scope string) (c
 	}
 
 	return result, nil
+}
+
+func getAuthority(authorityHost, tenantID string) string {
+	return fmt.Sprintf("%s/%s", strings.TrimRight(authorityHost, "/"), tenantID)
 }
 
 // readJWTFromFS reads the jwt from file system

--- a/pkg/utils/azureauth/authenticationUtils_test.go
+++ b/pkg/utils/azureauth/authenticationUtils_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azureauth
+
+import (
+	"context"
+	"os"
+	"testing"
+)
+
+func TestGetAuthority(t *testing.T) {
+	tests := []struct {
+		name          string
+		authorityHost string
+		tenantID      string
+		want          string
+	}{
+		{
+			name:          "authority host with trailing slash",
+			authorityHost: "https://login.microsoftonline.com/",
+			tenantID:      "tenant-id",
+			want:          "https://login.microsoftonline.com/tenant-id",
+		},
+		{
+			name:          "authority host without trailing slash",
+			authorityHost: "https://login.microsoftonline.com",
+			tenantID:      "tenant-id",
+			want:          "https://login.microsoftonline.com/tenant-id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getAuthority(tt.authorityHost, tt.tenantID); got != tt.want {
+				t.Fatalf("getAuthority() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetAADAccessTokenReturnsErrorForInvalidAuthority(t *testing.T) {
+	tokenFile := t.TempDir() + "/token"
+	if err := os.WriteFile(tokenFile, []byte("token"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("AZURE_FEDERATED_TOKEN_FILE", tokenFile)
+	t.Setenv("AZURE_AUTHORITY_HOST", "://invalid-authority")
+
+	if _, err := GetAADAccessToken(context.Background(), "tenant-id", "client-id", "scope"); err == nil {
+		t.Fatal("GetAADAccessToken() error = nil, want error")
+	}
+}


### PR DESCRIPTION
## What this PR does

Fixes Azure workload identity token acquisition by passing MSAL the tenant authority instead of the OAuth token endpoint.

With newer MSAL versions, passing `https://login.microsoftonline.com/{tenant}/oauth2/token` as the authority causes discovery to be resolved under that token endpoint, producing an invalid URL like:

```
Reconciler error Store=store-oras ...
AUTH_DENIED: Unable to create store from store CR:
failed to create auth provider from configuration:
failed to acquire AAD token:
unable to resolve an endpoint:
https://login.microsoftonline.com/.../oauth2/token/v2.0/.well-known/openid-configuration
```

```text
https://login.microsoftonline.com/{tenant}/oauth2/token/v2.0/.well-known/openid-configuration
```

This prevents Ratify from creating the ACR referrer store with `azureWorkloadIdentity`, which then surfaces as:

```text
CONFIG_INVALID: referrer store config should have at least one store
```

## Change

- Build the MSAL authority as `AZURE_AUTHORITY_HOST/{tenantID}`.
- Normalize a trailing slash on `AZURE_AUTHORITY_HOST`.
- Add unit coverage for both trailing-slash and non-trailing-slash authority hosts.

## Validation

```text
go test ./pkg/utils/azureauth ./pkg/common/oras/authprovider/azure
```