### PR TITLE
feat: Alpha.2 deployment blockers — health probes, StoreMux fallback, cert watcher

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -72,17 +72,19 @@ type Options struct {
 //   - Repository paths: "registry.example.com/namespace/repo" matches a
 //     specific repository
 //
-// Note: Top level domain wildcard is also not supported. That is, "*" is not a
-// valid pattern.
+// Note: Top level domain wildcard patterns like "*.com" are not supported.
+// The special scope value "*" is reserved for the global fallback executor.
 // Scope matching follows a precedence order from most specific to least
 // specific:
 //  1. Exact repository match
 //  2. Exact registry match
 //  3. Wildcard registry match
+//  4. Fallback executor
 type ScopedExecutor struct {
 	wildcard   map[string]*ratify.Executor
 	registry   map[string]*ratify.Executor
 	repository map[string]*ratify.Executor
+	fallback   *ratify.Executor
 }
 
 // NewScopedExecutor creates a new ScopedExecutor instance based on the provided
@@ -191,6 +193,9 @@ func (s *ScopedExecutor) matchExecutor(artifact string) (*ratify.Executor, error
 			return executor, nil
 		}
 	}
+	if s.fallback != nil {
+		return s.fallback, nil
+	}
 	return nil, fmt.Errorf("no executor configured for the artifact %q", artifact)
 }
 
@@ -201,6 +206,13 @@ func (s *ScopedExecutor) registerExecutor(scope string, executor *ratify.Executo
 	}
 	if executor == nil {
 		return fmt.Errorf("executor cannot be nil")
+	}
+	if scope == "*" {
+		if s.fallback != nil {
+			return fmt.Errorf("fallback executor already registered")
+		}
+		s.fallback = executor
+		return nil
 	}
 
 	if strings.Contains(scope, "/") {

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -112,7 +112,7 @@ func TestNewExecutor(t *testing.T) {
 			expectExecutor: false,
 		},
 		{
-			name: "invalid executor scopes",
+			name: "valid fallback scope",
 			opts: Options{
 				Executors: []ScopedOptions{
 					{
@@ -125,8 +125,7 @@ func TestNewExecutor(t *testing.T) {
 						},
 						Stores: []store.NewOptions{
 							{
-								Type:   mockStoreType,
-								Scopes: []string{"testrepo"},
+								Type: mockStoreType,
 							},
 						},
 						Policy: &policyenforcer.NewOptions{
@@ -135,8 +134,8 @@ func TestNewExecutor(t *testing.T) {
 					},
 				},
 			},
-			expectErr:      true,
-			expectExecutor: false,
+			expectErr:      false,
+			expectExecutor: true,
 		},
 		{
 			name: "failed to create store",
@@ -234,12 +233,14 @@ func TestRegisterExecutor(t *testing.T) {
 		wildcardScoped   bool
 		registryScoped   bool
 		repositoryScoped bool
+		fallbackScoped   bool
 	}{
 		{
-			name:          "Register executor with global wildcard scope",
-			scope:         "*",
-			executor:      &ratify.Executor{},
-			registerError: true,
+			name:           "Register executor with fallback scope",
+			scope:          "*",
+			executor:       &ratify.Executor{},
+			registerError:  false,
+			fallbackScoped: true,
 		},
 		{
 			name:          "Register executor with empty scope",
@@ -323,6 +324,9 @@ func TestRegisterExecutor(t *testing.T) {
 				if test.repositoryScoped && len(scopedExecutor.repository) == 0 {
 					t.Errorf("expected repository scoped executors to be registered, but got none")
 				}
+				if test.fallbackScoped && scopedExecutor.fallback == nil {
+					t.Errorf("expected fallback executor to be registered, but got none")
+				}
 			}
 		})
 	}
@@ -332,6 +336,7 @@ func TestMatchExecutor(t *testing.T) {
 	e1 := &ratify.Executor{}
 	e2 := &ratify.Executor{}
 	e3 := &ratify.Executor{}
+	e4 := &ratify.Executor{}
 	scopedExecutor := &ScopedExecutor{
 		wildcard: map[string]*ratify.Executor{
 			"example.com": e1,
@@ -342,6 +347,7 @@ func TestMatchExecutor(t *testing.T) {
 		repository: map[string]*ratify.Executor{
 			"registry.example.com/repository/foo": e3,
 		},
+		fallback: e4,
 	}
 	tests := []struct {
 		name             string
@@ -374,10 +380,10 @@ func TestMatchExecutor(t *testing.T) {
 			expectedError:    false,
 		},
 		{
-			name:             "No match",
+			name:             "Match fallback executor",
 			artifact:         "unknown.com/foo:v1",
-			expectedExecutor: nil,
-			expectedError:    true,
+			expectedExecutor: e4,
+			expectedError:    false,
 		},
 	}
 
@@ -399,10 +405,11 @@ func TestValidateArtifact(t *testing.T) {
 		wildcard: map[string]*ratify.Executor{
 			"example.com": {},
 		},
+		fallback: &ratify.Executor{},
 	}
 
 	if _, err := scopedExecutor.ValidateArtifact(context.Background(), "unknown.com/foo:v1"); err == nil {
-		t.Error("expected error for unknown artifact, got nil")
+		t.Error("expected error for fallback executor without store/verifiers, got nil")
 	}
 
 	if _, err := scopedExecutor.ValidateArtifact(context.Background(), "test.example.com/foo:v1"); err == nil {

--- a/internal/httpserver/health.go
+++ b/internal/httpserver/health.go
@@ -1,0 +1,67 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package httpserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"sync/atomic"
+)
+
+// healthStatus tracks whether the server is ready to serve traffic.
+type healthStatus struct {
+	alive atomic.Bool
+	ready atomic.Bool
+}
+
+type healthResponse struct {
+	Status string `json:"status"`
+}
+
+// healthzHandler returns 200 if the process is alive, 503 otherwise.
+// This is the Kubernetes liveness probe endpoint.
+func (s *server) healthzHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if !s.health.alive.Load() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			json.NewEncoder(w).Encode(healthResponse{Status: "not alive"}) //nolint:errcheck
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(healthResponse{Status: "ok"}) //nolint:errcheck
+	}
+}
+
+// readyzHandler returns 200 if the server has a valid executor configured
+// and is ready to handle verification requests.
+func (s *server) readyzHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if !s.health.ready.Load() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			json.NewEncoder(w).Encode(healthResponse{Status: "not ready"}) //nolint:errcheck
+			return
+		}
+		if s.getExecutor() == nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			json.NewEncoder(w).Encode(healthResponse{Status: "no executor configured"}) //nolint:errcheck
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(healthResponse{Status: "ok"}) //nolint:errcheck
+	}
+}

--- a/internal/httpserver/health_test.go
+++ b/internal/httpserver/health_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package httpserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/notaryproject/ratify/v2/internal/executor"
+)
+
+func TestHealthzHandler_Alive(t *testing.T) {
+	s := &server{
+		health: &healthStatus{},
+	}
+	s.health.alive.Store(true)
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	w := httptest.NewRecorder()
+	s.healthzHandler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", w.Code)
+	}
+	var resp healthResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Status != "ok" {
+		t.Errorf("expected status 'ok', got %q", resp.Status)
+	}
+}
+
+func TestHealthzHandler_NotAlive(t *testing.T) {
+	s := &server{
+		health: &healthStatus{},
+	}
+	// alive defaults to false
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	w := httptest.NewRecorder()
+	s.healthzHandler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected status 503, got %d", w.Code)
+	}
+	var resp healthResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Status != "not alive" {
+		t.Errorf("expected status 'not alive', got %q", resp.Status)
+	}
+}
+
+func TestReadyzHandler_NotReady(t *testing.T) {
+	s := &server{
+		health: &healthStatus{},
+	}
+	s.health.alive.Store(true)
+	// ready defaults to false
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	w := httptest.NewRecorder()
+	s.readyzHandler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected status 503, got %d", w.Code)
+	}
+}
+
+func TestReadyzHandler_NoExecutor(t *testing.T) {
+	s := &server{
+		health:      &healthStatus{},
+		getExecutor: func() *executor.ScopedExecutor { return nil },
+	}
+	s.health.alive.Store(true)
+	s.health.ready.Store(true)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	w := httptest.NewRecorder()
+	s.readyzHandler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected status 503, got %d", w.Code)
+	}
+	var resp healthResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Status != "no executor configured" {
+		t.Errorf("expected 'no executor configured', got %q", resp.Status)
+	}
+}
+
+func TestReadyzHandler_Ready(t *testing.T) {
+	s := &server{
+		health:      &healthStatus{},
+		getExecutor: func() *executor.ScopedExecutor { return &executor.ScopedExecutor{} },
+	}
+	s.health.alive.Store(true)
+	s.health.ready.Store(true)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	w := httptest.NewRecorder()
+	s.readyzHandler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", w.Code)
+	}
+	var resp healthResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Status != "ok" {
+		t.Errorf("expected status 'ok', got %q", resp.Status)
+	}
+}

--- a/internal/httpserver/server.go
+++ b/internal/httpserver/server.go
@@ -55,6 +55,7 @@ type server struct {
 	mutateCache cache.Cache[string]
 	verifyCache cache.Cache[*result]
 	sfGroup     *singleflight.Group
+	health      *healthStatus
 	ServerOptions
 }
 
@@ -145,12 +146,16 @@ func newServer(serverOpts *ServerOptions, executorConfigPath string) (*server, *
 		return nil, nil, fmt.Errorf("failed to create verify cache: %w", err)
 	}
 
+	health := &healthStatus{}
+	health.alive.Store(true)
+
 	server := &server{
 		router:        mux.NewRouter(),
 		mutateCache:   mutateCache,
 		verifyCache:   verifyCache,
 		sfGroup:       new(singleflight.Group),
 		getExecutor:   getExecutorFunc,
+		health:        health,
 		ServerOptions: *serverOpts,
 	}
 	if server.VerifyTimeout == 0 {
@@ -167,6 +172,10 @@ func newServer(serverOpts *ServerOptions, executorConfigPath string) (*server, *
 }
 
 func (s *server) registerHandlers() error {
+	// Health endpoints — no auth, no timeout middleware
+	s.router.Methods(http.MethodGet).Path("/healthz").HandlerFunc(s.healthzHandler())
+	s.router.Methods(http.MethodGet).Path("/readyz").HandlerFunc(s.readyzHandler())
+
 	if err := s.registerVerifyHandler(); err != nil {
 		return err
 	}
@@ -228,6 +237,18 @@ func (s *server) Run(certRotatorReady chan struct{}, configWatcher *config.Watch
 		ReadTimeout:  readTimeout,
 		IdleTimeout:  idleTimeout,
 	}
+	// Poll for executor availability and signal readiness.
+	go func() {
+		for {
+			if s.getExecutor() != nil {
+				s.health.ready.Store(true)
+				logrus.Info("server is ready: executor loaded")
+				return
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	}()
+
 	go func() {
 		// Start the configuration watcher (if any) and ensure
 		// it is properly stopped when the server goroutine exits.

--- a/internal/store/factory.go
+++ b/internal/store/factory.go
@@ -59,25 +59,49 @@ func New(opts []NewOptions, globalScopes []string) (ratify.Store, error) {
 	if len(opts) == 0 {
 		return nil, fmt.Errorf("no store options provided")
 	}
+
+	if len(opts) == 1 && len(opts[0].Scopes) == 0 && len(globalScopes) == 0 {
+		store, err := newStore(opts[0])
+		if err != nil {
+			return nil, fmt.Errorf("failed to create store for type %q: %w", opts[0].Type, err)
+		}
+		storeMux := ratify.NewStoreMux()
+		if err = storeMux.RegisterFallback(store); err != nil {
+			return nil, fmt.Errorf("failed to register fallback store: %w", err)
+		}
+		return storeMux, nil
+	}
+
 	// If there is more than one store option, clear the global scopes as
 	// multiple stores should not share the same global scopes.
 	if len(opts) > 1 {
 		globalScopes = []string{}
 	}
+
 	storeMux := ratify.NewStoreMux()
 	for _, storeOptions := range opts {
-		if len(storeOptions.Scopes) == 0 {
+		scopes := storeOptions.Scopes
+		if len(scopes) == 0 {
 			// if no scopes are provided, use the global scopes of the executor.
-			storeOptions.Scopes = globalScopes
+			scopes = globalScopes
 		}
-		if len(storeOptions.Scopes) == 0 {
-			return nil, fmt.Errorf("store options must contain at least one scope")
-		}
+
 		store, err := newStore(storeOptions)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create store for type %q: %w", storeOptions.Type, err)
 		}
-		for _, scope := range storeOptions.Scopes {
+
+		if len(scopes) == 1 && scopes[0] == "*" {
+			if err = storeMux.RegisterFallback(store); err != nil {
+				return nil, fmt.Errorf("failed to register fallback store: %w", err)
+			}
+			continue
+		}
+
+		if len(scopes) == 0 {
+			return nil, fmt.Errorf("store options must contain at least one scope")
+		}
+		for _, scope := range scopes {
 			if err = storeMux.Register(scope, store); err != nil {
 				return nil, fmt.Errorf("failed to register store for scope %q: %w", scope, err)
 			}

--- a/internal/store/factory_test.go
+++ b/internal/store/factory_test.go
@@ -162,15 +162,15 @@ func TestNew(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "invalid store scope",
+			name: "fallback store with star scope",
 			opts: []NewOptions{
 				{
 					Type:       "mock-store",
 					Parameters: map[string]any{},
+					Scopes:     []string{"*"},
 				},
 			},
-			globalScopes:  []string{"*"},
-			expectedError: true,
+			expectedError: false,
 		},
 		{
 			name: "multiple stores clear global scopes",
@@ -188,15 +188,24 @@ func TestNew(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "store registration failure with bad store type",
+			name: "store creation failure with fallback scope",
 			opts: []NewOptions{
 				{
 					Type:   "mock-store-with-error",
-					Scopes: []string{"*"}, // Invalid scope that causes Register to fail
+					Scopes: []string{"*"},
 				},
 			},
 			globalScopes:  []string{},
 			expectedError: true,
+		},
+		{
+			name: "single store without scopes registers fallback",
+			opts: []NewOptions{
+				{
+					Type: "mock-store",
+				},
+			},
+			expectedError: false,
 		},
 	}
 

--- a/internal/verifier/keyprovider/filesystemprovider/register.go
+++ b/internal/verifier/keyprovider/filesystemprovider/register.go
@@ -23,9 +23,11 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sync"
 
 	notationx509 "github.com/notaryproject/notation-core-go/x509"
 	"github.com/notaryproject/ratify/v2/internal/verifier/keyprovider"
+	verifiertruststore "github.com/notaryproject/ratify/v2/internal/verifier/truststore"
 	"github.com/sirupsen/logrus"
 )
 
@@ -36,6 +38,8 @@ const fileSystemProviderName = "files"
 type FileSystemProvider struct {
 	certPaths    []string
 	certificates []*x509.Certificate
+	watcher      *verifiertruststore.Watcher
+	mu           sync.RWMutex
 }
 
 func init() {
@@ -53,29 +57,54 @@ func init() {
 			return nil, fmt.Errorf("no file paths provided")
 		}
 
-		// Load certificates during initialization
-		var allCertificates []*x509.Certificate
-		for _, certPath := range paths {
-			certificates, err := loadCertificatesFromPath(certPath)
-			if err != nil {
-				return nil, fmt.Errorf("failed to load certificates from path %s: %w", certPath, err)
-			}
-			allCertificates = append(allCertificates, certificates...)
+		provider := &FileSystemProvider{certPaths: paths}
+		if err := provider.reloadCertificates(); err != nil {
+			return nil, err
 		}
 
-		return &FileSystemProvider{
-			certPaths:    paths,
-			certificates: allCertificates,
-		}, nil
+		watcher, err := verifiertruststore.NewWatcher(paths, func() {
+			if err := provider.reloadCertificates(); err != nil {
+				logrus.WithError(err).Error("failed to reload trust store certificates")
+			}
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create trust store watcher: %w", err)
+		}
+		if err := watcher.Start(); err != nil {
+			watcher.Stop()
+			return nil, fmt.Errorf("failed to start trust store watcher: %w", err)
+		}
+		provider.watcher = watcher
+		return provider, nil
 	})
 }
 
 // FileSystemProvider implements GetCertificates of [truststore.X509TrustStore]
 // interface.
 func (f *FileSystemProvider) GetCertificates(_ context.Context) ([]*x509.Certificate, error) {
-	// Return cached certificates loaded during initialization
-	logrus.Debugf("Returning %d cached certificate(s) from file system", len(f.certificates))
-	return f.certificates, nil
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	certificates := make([]*x509.Certificate, len(f.certificates))
+	copy(certificates, f.certificates)
+	logrus.Debugf("Returning %d cached certificate(s) from file system", len(certificates))
+	return certificates, nil
+}
+
+func (f *FileSystemProvider) reloadCertificates() error {
+	var allCertificates []*x509.Certificate
+	for _, certPath := range f.certPaths {
+		certificates, err := loadCertificatesFromPath(certPath)
+		if err != nil {
+			return fmt.Errorf("failed to load certificates from path %s: %w", certPath, err)
+		}
+		allCertificates = append(allCertificates, certificates...)
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.certificates = allCertificates
+	return nil
 }
 
 func (f *FileSystemProvider) GetKeys(_ context.Context) ([]*keyprovider.PublicKey, error) {

--- a/internal/verifier/keyprovider/filesystemprovider/register_test.go
+++ b/internal/verifier/keyprovider/filesystemprovider/register_test.go
@@ -89,7 +89,7 @@ func TestGetCertificates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get certificates: %v", err)
 	}
-	if len(certs) != 1 {
+	if len(certs) == 0 {
 		t.Fatalf("expected at least one certificate, got %d", len(certs))
 	}
 
@@ -102,7 +102,7 @@ func TestGetCertificates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get certificates: %v", err)
 	}
-	if len(certs) != 1 {
+	if len(certs) == 0 {
 		t.Fatalf("expected at least one certificate, got %d", len(certs))
 	}
 
@@ -120,10 +120,9 @@ func TestGetCertificates(t *testing.T) {
 	}
 }
 
-func TestGetCertificatesFromCache(t *testing.T) {
+func TestGetCertificatesReloadsAfterFileChange(t *testing.T) {
 	tempDir := t.TempDir()
 
-	// Create a temporary certificate file.
 	certFile := filepath.Join(tempDir, "test-cert.pem")
 	certContent, err := createCert()
 	if err != nil {
@@ -133,40 +132,36 @@ func TestGetCertificatesFromCache(t *testing.T) {
 		t.Fatalf("failed to create temp cert file: %v", err)
 	}
 
-	// Create provider which should load certificates during initialization
-	opts := []string{tempDir}
-	provider, err := keyprovider.CreateKeyProvider(fileSystemProviderName, opts)
+	provider, err := keyprovider.CreateKeyProvider(fileSystemProviderName, []string{tempDir})
 	if err != nil {
 		t.Fatalf("failed to create key provider: %v", err)
 	}
 
-	// Get certificates first time
-	certs1, err := provider.GetCertificates(context.Background())
+	certs, err := provider.GetCertificates(context.Background())
 	if err != nil {
 		t.Fatalf("failed to get certificates: %v", err)
 	}
-	if len(certs1) != 1 {
-		t.Fatalf("expected 1 certificate, got %d", len(certs1))
+	if len(certs) == 0 {
+		t.Fatalf("expected at least one certificate, got %d", len(certs))
 	}
 
-	// Remove the certificate file to ensure we're getting from cache
 	if err := os.Remove(certFile); err != nil {
 		t.Fatalf("failed to remove cert file: %v", err)
 	}
 
-	// Get certificates second time - should still work from cache
-	certs2, err := provider.GetCertificates(context.Background())
-	if err != nil {
-		t.Fatalf("failed to get certificates from cache: %v", err)
-	}
-	if len(certs2) != 1 {
-		t.Fatalf("expected 1 cached certificate, got %d", len(certs2))
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		certs, err = provider.GetCertificates(context.Background())
+		if err != nil {
+			t.Fatalf("failed to get certificates after removal: %v", err)
+		}
+		if len(certs) == 0 {
+			return
+		}
+		time.Sleep(200 * time.Millisecond)
 	}
 
-	// Verify both calls return the same certificate
-	if !certs1[0].Equal(certs2[0]) {
-		t.Fatalf("cached certificate doesn't match original")
-	}
+	t.Fatalf("expected watcher to reload certificates after file removal, still have %d", len(certs))
 }
 
 func TestGetKeys(t *testing.T) {

--- a/internal/verifier/truststore/watcher.go
+++ b/internal/verifier/truststore/watcher.go
@@ -1,0 +1,260 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package truststore
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	debounceInterval = 2 * time.Second
+	pollInterval     = 30 * time.Second
+)
+
+type ChangeCallback func()
+
+type Watcher struct {
+	watcher  *fsnotify.Watcher
+	paths    []string
+	callback ChangeCallback
+	done     chan struct{}
+	hashes   map[string][32]byte
+
+	mu       sync.Mutex
+	stopOnce sync.Once
+}
+
+func NewWatcher(paths []string, callback ChangeCallback) (*Watcher, error) {
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("at least one path must be provided")
+	}
+	if callback == nil {
+		return nil, fmt.Errorf("callback must not be nil")
+	}
+
+	fsWatcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create fsnotify watcher: %w", err)
+	}
+
+	w := &Watcher{
+		watcher:  fsWatcher,
+		paths:    append([]string(nil), paths...),
+		callback: callback,
+		done:     make(chan struct{}),
+		hashes:   make(map[string][32]byte),
+	}
+	w.snapshotHashes()
+	return w, nil
+}
+
+func (w *Watcher) Start() error {
+	for _, path := range w.paths {
+		if err := w.addPath(path); err != nil {
+			logrus.WithError(err).Warnf("failed to watch path %s", path)
+		}
+	}
+
+	go w.watch()
+	go w.pollLoop()
+	return nil
+}
+
+func (w *Watcher) Stop() {
+	w.stopOnce.Do(func() {
+		close(w.done)
+		if err := w.watcher.Close(); err != nil {
+			logrus.WithError(err).Error("error closing trust store watcher")
+		}
+	})
+}
+
+func (w *Watcher) AddPath(path string) error {
+	w.mu.Lock()
+	for _, existing := range w.paths {
+		if existing == path {
+			w.mu.Unlock()
+			return nil
+		}
+	}
+	w.mu.Unlock()
+
+	if err := w.addPath(path); err != nil {
+		return err
+	}
+
+	w.mu.Lock()
+	w.paths = append(w.paths, path)
+	w.mu.Unlock()
+	w.snapshotHashes()
+	return nil
+}
+
+func (w *Watcher) addPath(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("failed to stat path %s: %w", path, err)
+	}
+	if err := w.watcher.Add(path); err != nil {
+		return fmt.Errorf("failed to watch path %s: %w", path, err)
+	}
+	if info.IsDir() {
+		parent := filepath.Dir(path)
+		if parent != path {
+			_ = w.watcher.Add(parent)
+		}
+	}
+	return nil
+}
+
+func (w *Watcher) watch() {
+	var debounceTimer *time.Timer
+	for {
+		select {
+		case event, ok := <-w.watcher.Events:
+			if !ok {
+				return
+			}
+			if event.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Remove|fsnotify.Rename) == 0 {
+				continue
+			}
+			logrus.Debugf("trust store watcher event: %s %s", event.Op, event.Name)
+			if event.Op&(fsnotify.Remove|fsnotify.Rename) != 0 {
+				_ = w.watcher.Add(event.Name)
+			}
+			if debounceTimer != nil {
+				debounceTimer.Stop()
+			}
+			debounceTimer = time.AfterFunc(debounceInterval, func() {
+				logrus.Infof("trust store cert change detected: %s", event.Name)
+				w.callback()
+				w.snapshotHashes()
+			})
+		case err, ok := <-w.watcher.Errors:
+			if !ok {
+				return
+			}
+			logrus.WithError(err).Error("trust store watcher error")
+		case <-w.done:
+			if debounceTimer != nil {
+				debounceTimer.Stop()
+			}
+			return
+		}
+	}
+}
+
+func (w *Watcher) pollLoop() {
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			if w.certsChanged() {
+				logrus.Info("trust store cert change detected via polling")
+				w.callback()
+				w.snapshotHashes()
+			}
+		case <-w.done:
+			return
+		}
+	}
+}
+
+func (w *Watcher) certsChanged() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	for _, path := range w.paths {
+		if w.checkPathChanged(path) {
+			return true
+		}
+	}
+	return false
+}
+
+func (w *Watcher) checkPathChanged(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	if info.IsDir() {
+		changed := false
+		_ = filepath.WalkDir(path, func(filePath string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return nil
+			}
+			if w.fileHashChanged(filePath) {
+				changed = true
+			}
+			return nil
+		})
+		return changed
+	}
+	return w.fileHashChanged(path)
+}
+
+func (w *Watcher) fileHashChanged(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	hash := sha256.Sum256(data)
+	if previous, ok := w.hashes[path]; ok {
+		return hash != previous
+	}
+	return true
+}
+
+func (w *Watcher) snapshotHashes() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	for _, path := range w.paths {
+		info, err := os.Stat(path)
+		if err != nil {
+			continue
+		}
+		if info.IsDir() {
+			_ = filepath.WalkDir(path, func(filePath string, d fs.DirEntry, err error) error {
+				if err != nil || d.IsDir() {
+					return nil
+				}
+				data, err := os.ReadFile(filePath)
+				if err != nil {
+					return nil
+				}
+				w.hashes[filePath] = sha256.Sum256(data)
+				return nil
+			})
+			continue
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		w.hashes[path] = sha256.Sum256(data)
+	}
+}

--- a/internal/verifier/truststore/watcher_test.go
+++ b/internal/verifier/truststore/watcher_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package truststore
+
+import (
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestNewWatcher_NoPaths(t *testing.T) {
+	_, err := NewWatcher(nil, func() {})
+	if err == nil {
+		t.Fatal("expected error for nil paths")
+	}
+}
+
+func TestNewWatcher_NilCallback(t *testing.T) {
+	dir := t.TempDir()
+	_, err := NewWatcher([]string{dir}, nil)
+	if err == nil {
+		t.Fatal("expected error for nil callback")
+	}
+}
+
+func TestWatcher_FileWriteTriggersCallback(t *testing.T) {
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "ca.crt")
+	if err := os.WriteFile(certFile, []byte("initial-cert"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var calls atomic.Int32
+	watcher, err := NewWatcher([]string{dir}, func() { calls.Add(1) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := watcher.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer watcher.Stop()
+
+	time.Sleep(100 * time.Millisecond)
+	if err := os.WriteFile(certFile, []byte("rotated-cert"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(3 * time.Second)
+	if calls.Load() == 0 {
+		t.Fatal("expected callback after cert write")
+	}
+}
+
+func TestWatcher_PollDetectsChanges(t *testing.T) {
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "ca.crt")
+	if err := os.WriteFile(certFile, []byte("original"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	watcher, err := NewWatcher([]string{dir}, func() {})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	watcher.snapshotHashes()
+	if err := os.WriteFile(certFile, []byte("modified"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !watcher.certsChanged() {
+		t.Fatal("expected poller to detect modified cert")
+	}
+}
+
+func TestWatcher_AddPathAndStop(t *testing.T) {
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+
+	watcher, err := NewWatcher([]string{dir1}, func() {})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := watcher.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := watcher.AddPath(dir2); err != nil {
+		t.Fatalf("failed to add path: %v", err)
+	}
+	if err := watcher.AddPath(dir2); err != nil {
+		t.Fatalf("duplicate add should not error: %v", err)
+	}
+	if len(watcher.paths) != 2 {
+		t.Fatalf("expected 2 watched paths, got %d", len(watcher.paths))
+	}
+
+	watcher.Stop()
+	watcher.Stop()
+}


### PR DESCRIPTION
## Summary
- add flat `/healthz` and `/readyz` probe endpoints for the gatekeeper provider
- support `"*"` as the StoreMux and executor fallback scope, including single-store no-scope fallback registration
- add a trust-store certificate watcher with fsnotify + SHA-256 polling and wire filesystem key providers to reload rotated certs

## Key design decisions
- probe endpoints stay outside the `/ratify/gatekeeper/v2` API namespace and bypass auth/timeout middleware
- `"*"` maps to explicit fallback registration instead of overloading wildcard registry matching
- cert reload uses debounced fsnotify events plus polling to handle Kubernetes symlink-swap secret updates

## Validation
- `go test ./internal/httpserver ./internal/store ./internal/executor ./internal/verifier ./internal/verifier/notation ./internal/verifier/truststore ./internal/verifier/keyprovider/filesystemprovider`

Draft pending Deckard review.