### PR TITLE
feat: add benchmark regression gate and executor benchmarks for Perf test

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup go environment
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: "1.24"
+          go-version: "1.26"
 
       # Run the current tree's benchmarks. On push to main this records a
       # baseline only; the gate below runs on pull requests.

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -55,48 +55,32 @@ jobs:
         with:
           go-version: "1.24"
 
-      - name: Install benchstat
-        # Pin to a specific version so benchmark gating stays deterministic and
-        # reproducible over time (changes in benchstat analysis/output must be
-        # adopted intentionally rather than silently breaking unchanged PRs).
-        run: go install golang.org/x/perf/cmd/benchstat@v0.0.0-20260512194132-3cf34090a3db
-
+      # Run the current tree's benchmarks. On push to main this records a
+      # baseline only; the gate below runs on pull requests.
       - name: Run benchmarks (PR head)
-        run: make benchmark BENCH_COUNT=${{ env.BENCH_COUNT }} BENCH_OUT=head.txt
+        run: make benchmark BENCH_COUNT=${{ env.BENCH_COUNT }}
 
-      # On pull requests, also benchmark the base branch so we can compare and
-      # gate regressions. On push to main there is no baseline to compare to,
-      # so we only record the results above.
-      #
-      # We check out `pull_request.base.sha` (the base branch tip at event
-      # time). This is not necessarily the git merge-base, but GitHub already
-      # runs this workflow against the PR's merge commit, so the base tip is the
-      # most representative baseline and keeps the step simple.
-      #
-      # The base commit may predate the `benchmark` Makefile target (this PR
-      # may be the change that introduces it), so run `go test -bench` directly
-      # against the base worktree instead of relying on its Makefile. Any
-      # benchmark that exists only at HEAD simply has no base counterpart and
-      # therefore cannot be flagged as a regression.
+      # On pull requests, also benchmark the base branch tip and gate on
+      # regressions. The benchmark logic lives in the Makefile so it can be
+      # reproduced and debugged locally (e.g. `make benchmark-ci`). The base
+      # tip is used as the baseline; GitHub already runs this workflow against
+      # the PR's merge commit, so it is the most representative comparison.
       - name: Run benchmarks (base branch)
         if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          # Always remove the worktree on exit so a benchmark failure does not
-          # leave a stale worktree behind for later steps/jobs on the runner.
-          trap 'git worktree remove --force ../base 2>/dev/null || true' EXIT
-          git worktree add --detach ../base "${{ github.event.pull_request.base.sha }}"
-          ( cd ../base && go test -run='^$' -bench=. -benchmem -count=${{ env.BENCH_COUNT }} ./... ) | tee "${GITHUB_WORKSPACE}/base.txt"
+        run: make benchmark-base BENCH_COUNT=${{ env.BENCH_COUNT }} BENCH_BASE_REF=${{ github.event.pull_request.base.sha }}
 
       - name: Gate on benchmark regressions
         if: ${{ github.event_name == 'pull_request' }}
-        run: ./scripts/benchmark-gate.sh base.txt head.txt "${{ env.THRESHOLD_PCT }}" | tee "${GITHUB_STEP_SUMMARY}"
+        run: make benchmark-gate BENCH_THRESHOLD=${{ env.THRESHOLD_PCT }} | tee "${GITHUB_STEP_SUMMARY}"
 
+      # Always upload the raw results so a failed gate can be troubleshooted by
+      # inspecting the head and base benchmark output.
       - name: Upload benchmark results
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         if: ${{ always() }}
         with:
           name: benchmark-results
           path: |
-            head.txt
-            base.txt
+            benchmark-head.txt
+            benchmark-base.txt
           if-no-files-found: ignore

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -56,7 +56,10 @@ jobs:
           go-version: "1.24"
 
       - name: Install benchstat
-        run: go install golang.org/x/perf/cmd/benchstat@latest
+        # Pin to a specific version so benchmark gating stays deterministic and
+        # reproducible over time (changes in benchstat analysis/output must be
+        # adopted intentionally rather than silently breaking unchanged PRs).
+        run: go install golang.org/x/perf/cmd/benchstat@v0.0.0-20260512194132-3cf34090a3db
 
       - name: Run benchmarks (PR head)
         run: make benchmark BENCH_COUNT=${{ env.BENCH_COUNT }} BENCH_OUT=head.txt

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -64,9 +64,14 @@ jobs:
       - name: Run benchmarks (PR head)
         run: make benchmark BENCH_COUNT=${{ env.BENCH_COUNT }} BENCH_OUT=head.txt
 
-      # On pull requests, also benchmark the merge base so we can compare and
+      # On pull requests, also benchmark the base branch so we can compare and
       # gate regressions. On push to main there is no baseline to compare to,
       # so we only record the results above.
+      #
+      # We check out `pull_request.base.sha` (the base branch tip at event
+      # time). This is not necessarily the git merge-base, but GitHub already
+      # runs this workflow against the PR's merge commit, so the base tip is the
+      # most representative baseline and keeps the step simple.
       #
       # The base commit may predate the `benchmark` Makefile target (this PR
       # may be the change that introduces it), so run `go test -bench` directly
@@ -76,9 +81,11 @@ jobs:
       - name: Run benchmarks (base branch)
         if: ${{ github.event_name == 'pull_request' }}
         run: |
+          # Always remove the worktree on exit so a benchmark failure does not
+          # leave a stale worktree behind for later steps/jobs on the runner.
+          trap 'git worktree remove --force ../base 2>/dev/null || true' EXIT
           git worktree add --detach ../base "${{ github.event.pull_request.base.sha }}"
           ( cd ../base && go test -run='^$' -bench=. -benchmem -count=${{ env.BENCH_COUNT }} ./... ) | tee "${GITHUB_WORKSPACE}/base.txt"
-          git worktree remove --force ../base
 
       - name: Gate on benchmark regressions
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -64,11 +64,17 @@ jobs:
       # On pull requests, also benchmark the merge base so we can compare and
       # gate regressions. On push to main there is no baseline to compare to,
       # so we only record the results above.
+      #
+      # The base commit may predate the `benchmark` Makefile target (this PR
+      # may be the change that introduces it), so run `go test -bench` directly
+      # against the base worktree instead of relying on its Makefile. Any
+      # benchmark that exists only at HEAD simply has no base counterpart and
+      # therefore cannot be flagged as a regression.
       - name: Run benchmarks (base branch)
         if: ${{ github.event_name == 'pull_request' }}
         run: |
           git worktree add --detach ../base "${{ github.event.pull_request.base.sha }}"
-          make -C ../base benchmark BENCH_COUNT=${{ env.BENCH_COUNT }} BENCH_OUT="${GITHUB_WORKSPACE}/base.txt"
+          ( cd ../base && go test -run='^$' -bench=. -benchmem -count=${{ env.BENCH_COUNT }} ./... ) | tee "${GITHUB_WORKSPACE}/base.txt"
           git worktree remove --force ../base
 
       - name: Gate on benchmark regressions

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,86 @@
+# Copyright The Ratify Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: benchmark
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - "docs/**"
+      - "library/**"
+      - "**.md"
+  workflow_dispatch:
+
+permissions: read-all
+
+env:
+  # Maximum allowed regression (percent) before the gate fails a PR.
+  THRESHOLD_PCT: "20"
+  # Number of times each benchmark is run to reduce measurement noise.
+  BENCH_COUNT: "10"
+
+jobs:
+  benchmark:
+    name: "Run benchmarks and gate regressions"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Setup go environment
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: "1.24"
+
+      - name: Install benchstat
+        run: go install golang.org/x/perf/cmd/benchstat@latest
+
+      - name: Run benchmarks (PR head)
+        run: make benchmark BENCH_COUNT=${{ env.BENCH_COUNT }} BENCH_OUT=head.txt
+
+      # On pull requests, also benchmark the merge base so we can compare and
+      # gate regressions. On push to main there is no baseline to compare to,
+      # so we only record the results above.
+      - name: Run benchmarks (base branch)
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          git worktree add --detach ../base "${{ github.event.pull_request.base.sha }}"
+          make -C ../base benchmark BENCH_COUNT=${{ env.BENCH_COUNT }} BENCH_OUT="${GITHUB_WORKSPACE}/base.txt"
+          git worktree remove --force ../base
+
+      - name: Gate on benchmark regressions
+        if: ${{ github.event_name == 'pull_request' }}
+        run: ./scripts/benchmark-gate.sh base.txt head.txt "${{ env.THRESHOLD_PCT }}" | tee "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        if: ${{ always() }}
+        with:
+          name: benchmark-results
+          path: |
+            head.txt
+            base.txt
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,4 @@ certs/
 
 pkg/referrerstore/factory/plugin-store
 
-bench.txt
-head.txt
-base.txt
+benchmark*.txt

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ certs/
 
 pkg/referrerstore/factory/plugin-store
 
+bench.txt
+head.txt
+base.txt

--- a/Makefile
+++ b/Makefile
@@ -117,8 +117,8 @@ BENCH_OUT ?= bench.txt
 .PHONY: benchmark
 benchmark: ## Run Go benchmarks and write results to $(BENCH_OUT).
 	# Run under bash with pipefail so a `go test` failure is not masked by tee's
-	# (usually zero) exit status.
-	bash -o pipefail -c 'go test -run="^$$" -bench=. -benchmem -count=$(BENCH_COUNT) ./... | tee $(BENCH_OUT)'
+	# (usually zero) exit status. Quote the output path so it survives spaces.
+	bash -o pipefail -c 'go test -run="^$$" -bench=. -benchmem -count=$(BENCH_COUNT) ./... | tee "$(BENCH_OUT)"'
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,16 @@ ratify-config:
 test: setup-envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -v -coverprofile=coverage.txt -covermode=atomic ./...
 
+# BENCH_COUNT controls how many times each benchmark is run; more runs reduce
+# noise and improve the reliability of benchstat comparisons.
+BENCH_COUNT ?= 10
+# BENCH_OUT is the file the raw benchmark results are written to.
+BENCH_OUT ?= bench.txt
+
+.PHONY: benchmark
+benchmark: ## Run Go benchmarks and write results to $(BENCH_OUT).
+	go test -run='^$$' -bench=. -benchmem -count=$(BENCH_COUNT) ./... | tee $(BENCH_OUT)
+
 .PHONY: clean
 clean:
 	go clean

--- a/Makefile
+++ b/Makefile
@@ -381,6 +381,7 @@ e2e-notation-crl-setup:
 	${GITHUB_WORKSPACE}/bin/oras cp --from-oci-layout .staging/notation/notation.tar:v0 ${TEST_REGISTRY}/notation:crl
 	rm .staging/notation/notation.tar
 	NOTATION_EXPERIMENTAL=1 .staging/notation/notation sign -u ${TEST_REGISTRY_USERNAME} -p ${TEST_REGISTRY_PASSWORD} --key "crl-test" ${TEST_REGISTRY}/notation@`${GITHUB_WORKSPACE}/bin/oras manifest fetch ${TEST_REGISTRY}/notation:crl --descriptor | jq .digest | xargs`
+	python3 ./scripts/crl_server.py & echo "started crl server"
 
 e2e-cosign-setup:
 	rm -rf .staging/cosign

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,9 @@ BENCH_OUT ?= bench.txt
 
 .PHONY: benchmark
 benchmark: ## Run Go benchmarks and write results to $(BENCH_OUT).
-	go test -run='^$$' -bench=. -benchmem -count=$(BENCH_COUNT) ./... | tee $(BENCH_OUT)
+	# Run under bash with pipefail so a `go test` failure is not masked by tee's
+	# (usually zero) exit status.
+	bash -o pipefail -c 'go test -run="^$$" -bench=. -benchmem -count=$(BENCH_COUNT) ./... | tee $(BENCH_OUT)'
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ test-e2e: generate-rotation-certs
 	EXPIRING_CERT_DIR=.staging/rotation/expiring-certs CERT_DIR=.staging/rotation GATEKEEPER_VERSION=${GATEKEEPER_VERSION} bats -t ${BATS_PLUGIN_TESTS_FILE}
 
 .PHONY: test-e2e-cli
-test-e2e-cli: e2e-dependencies e2e-create-local-registry e2e-notation-setup e2e-notation-leaf-cert-setup e2e-notation-crl-setup e2e-notation-multiarch-setup e2e-cosign-setup e2e-licensechecker-setup e2e-sbom-setup e2e-trivy-setup e2e-schemavalidator-setup e2e-vulnerabilityreport-setup
+test-e2e-cli: e2e-dependencies e2e-create-local-registry e2e-notation-setup e2e-notation-leaf-cert-setup e2e-notation-crl-setup e2e-cosign-setup e2e-licensechecker-setup e2e-sbom-setup e2e-trivy-setup e2e-schemavalidator-setup e2e-vulnerabilityreport-setup
 	rm ${GOCOVERDIR} -rf
 	mkdir ${GOCOVERDIR} -p
 	RATIFY_DIR=${INSTALL_DIR} TEST_REGISTRY=${TEST_REGISTRY} ${GITHUB_WORKSPACE}/bin/bats -t ${BATS_CLI_TESTS_FILE}
@@ -381,28 +381,6 @@ e2e-notation-crl-setup:
 	${GITHUB_WORKSPACE}/bin/oras cp --from-oci-layout .staging/notation/notation.tar:v0 ${TEST_REGISTRY}/notation:crl
 	rm .staging/notation/notation.tar
 	NOTATION_EXPERIMENTAL=1 .staging/notation/notation sign -u ${TEST_REGISTRY_USERNAME} -p ${TEST_REGISTRY_PASSWORD} --key "crl-test" ${TEST_REGISTRY}/notation@`${GITHUB_WORKSPACE}/bin/oras manifest fetch ${TEST_REGISTRY}/notation:crl --descriptor | jq .digest | xargs`
-
-e2e-notation-multiarch-setup:
-	rm -rf .staging/notation/multiarch
-	mkdir -p .staging/notation/multiarch
-
-	# Build a multi-arch image index (manifest list) and push the signed variant
-	printf 'FROM ${ALPINE_IMAGE}\nCMD ["echo", "notation multiarch signed image"]' > .staging/notation/multiarch/Dockerfile
-	docker buildx create --use
-	docker buildx build --platform linux/amd64,linux/arm64 --output type=oci,dest=.staging/notation/multiarch/multiarch.tar -t notation-multiarch:v0 .staging/notation/multiarch
-	${GITHUB_WORKSPACE}/bin/oras cp --from-oci-layout .staging/notation/multiarch/multiarch.tar:v0 ${TEST_REGISTRY}/notation:multiarch-signed
-	rm .staging/notation/multiarch/multiarch.tar
-
-	# Build a separate multi-arch image index and push it unsigned (negative case)
-	printf 'FROM ${ALPINE_IMAGE}\nCMD ["echo", "notation multiarch unsigned image"]' > .staging/notation/multiarch/Dockerfile
-	docker buildx create --use
-	docker buildx build --platform linux/amd64,linux/arm64 --output type=oci,dest=.staging/notation/multiarch/multiarch.tar -t notation-multiarch:v0 .staging/notation/multiarch
-	${GITHUB_WORKSPACE}/bin/oras cp --from-oci-layout .staging/notation/multiarch/multiarch.tar:v0 ${TEST_REGISTRY}/notation:multiarch-unsigned
-	rm .staging/notation/multiarch/multiarch.tar
-
-	# Sign the image index digest with the default notation test key
-	NOTATION_EXPERIMENTAL=1 .staging/notation/notation sign --allow-referrers-api -u ${TEST_REGISTRY_USERNAME} -p ${TEST_REGISTRY_PASSWORD} ${TEST_REGISTRY}/notation@`${GITHUB_WORKSPACE}/bin/oras manifest fetch ${TEST_REGISTRY}/notation:multiarch-signed --descriptor | jq .digest | xargs`
-	python3 ./scripts/crl_server.py & echo "started crl server"
 
 e2e-cosign-setup:
 	rm -rf .staging/cosign

--- a/Makefile
+++ b/Makefile
@@ -111,14 +111,40 @@ test: setup-envtest ## Run tests.
 # BENCH_COUNT controls how many times each benchmark is run; more runs reduce
 # noise and improve the reliability of benchstat comparisons.
 BENCH_COUNT ?= 10
-# BENCH_OUT is the file the raw benchmark results are written to.
-BENCH_OUT ?= bench.txt
+# Self-documenting result files. BENCH_HEAD holds the current tree's results,
+# BENCH_BASE holds the comparison baseline's results.
+BENCH_HEAD ?= benchmark-head.txt
+BENCH_BASE ?= benchmark-base.txt
+# Maximum allowed regression (percent) before the gate fails.
+BENCH_THRESHOLD ?= 20
+# Commit-ish to benchmark as the comparison baseline (used by benchmark-base).
+BENCH_BASE_REF ?= origin/main
 
 .PHONY: benchmark
-benchmark: ## Run Go benchmarks and write results to $(BENCH_OUT).
+benchmark: ## Run Go benchmarks for the current tree into $(BENCH_HEAD).
 	# Run under bash with pipefail so a `go test` failure is not masked by tee's
 	# (usually zero) exit status. Quote the output path so it survives spaces.
-	bash -o pipefail -c 'go test -run="^$$" -bench=. -benchmem -count=$(BENCH_COUNT) ./... | tee "$(BENCH_OUT)"'
+	bash -o pipefail -c 'go test -run="^$$" -bench=. -benchmem -count=$(BENCH_COUNT) ./... | tee "$(BENCH_HEAD)"'
+
+.PHONY: benchmark-base
+benchmark-base: ## Run benchmarks for $(BENCH_BASE_REF) in a temp worktree into $(BENCH_BASE).
+	# Benchmark the baseline in a detached worktree so the current tree is left
+	# untouched. The worktree is always removed on exit, even on failure. The
+	# baseline may predate this target, so invoke `go test -bench` directly
+	# rather than relying on its Makefile.
+	bash -o pipefail -c '\
+		set -e; \
+		worktree="$$(mktemp -d)"; \
+		trap "git worktree remove --force \"$$worktree\" 2>/dev/null || true" EXIT; \
+		git worktree add --detach "$$worktree" "$(BENCH_BASE_REF)"; \
+		( cd "$$worktree" && go test -run="^$$" -bench=. -benchmem -count=$(BENCH_COUNT) ./... ) | tee "$(BENCH_BASE)"'
+
+.PHONY: benchmark-gate
+benchmark-gate: ## Compare $(BENCH_BASE) vs $(BENCH_HEAD) and fail on regressions.
+	THRESHOLD_PCT=$(BENCH_THRESHOLD) ./scripts/benchmark-gate.sh "$(BENCH_BASE)" "$(BENCH_HEAD)" "$(BENCH_THRESHOLD)"
+
+.PHONY: benchmark-ci
+benchmark-ci: benchmark benchmark-base benchmark-gate ## Run head + base benchmarks and gate regressions.
 
 .PHONY: clean
 clean:
@@ -172,7 +198,7 @@ test-e2e: generate-rotation-certs
 	EXPIRING_CERT_DIR=.staging/rotation/expiring-certs CERT_DIR=.staging/rotation GATEKEEPER_VERSION=${GATEKEEPER_VERSION} bats -t ${BATS_PLUGIN_TESTS_FILE}
 
 .PHONY: test-e2e-cli
-test-e2e-cli: e2e-dependencies e2e-create-local-registry e2e-notation-setup e2e-notation-leaf-cert-setup e2e-notation-crl-setup e2e-cosign-setup e2e-licensechecker-setup e2e-sbom-setup e2e-trivy-setup e2e-schemavalidator-setup e2e-vulnerabilityreport-setup
+test-e2e-cli: e2e-dependencies e2e-create-local-registry e2e-notation-setup e2e-notation-leaf-cert-setup e2e-notation-crl-setup e2e-notation-multiarch-setup e2e-cosign-setup e2e-licensechecker-setup e2e-sbom-setup e2e-trivy-setup e2e-schemavalidator-setup e2e-vulnerabilityreport-setup
 	rm ${GOCOVERDIR} -rf
 	mkdir ${GOCOVERDIR} -p
 	RATIFY_DIR=${INSTALL_DIR} TEST_REGISTRY=${TEST_REGISTRY} ${GITHUB_WORKSPACE}/bin/bats -t ${BATS_CLI_TESTS_FILE}
@@ -355,6 +381,27 @@ e2e-notation-crl-setup:
 	${GITHUB_WORKSPACE}/bin/oras cp --from-oci-layout .staging/notation/notation.tar:v0 ${TEST_REGISTRY}/notation:crl
 	rm .staging/notation/notation.tar
 	NOTATION_EXPERIMENTAL=1 .staging/notation/notation sign -u ${TEST_REGISTRY_USERNAME} -p ${TEST_REGISTRY_PASSWORD} --key "crl-test" ${TEST_REGISTRY}/notation@`${GITHUB_WORKSPACE}/bin/oras manifest fetch ${TEST_REGISTRY}/notation:crl --descriptor | jq .digest | xargs`
+
+e2e-notation-multiarch-setup:
+	rm -rf .staging/notation/multiarch
+	mkdir -p .staging/notation/multiarch
+
+	# Build a multi-arch image index (manifest list) and push the signed variant
+	printf 'FROM ${ALPINE_IMAGE}\nCMD ["echo", "notation multiarch signed image"]' > .staging/notation/multiarch/Dockerfile
+	docker buildx create --use
+	docker buildx build --platform linux/amd64,linux/arm64 --output type=oci,dest=.staging/notation/multiarch/multiarch.tar -t notation-multiarch:v0 .staging/notation/multiarch
+	${GITHUB_WORKSPACE}/bin/oras cp --from-oci-layout .staging/notation/multiarch/multiarch.tar:v0 ${TEST_REGISTRY}/notation:multiarch-signed
+	rm .staging/notation/multiarch/multiarch.tar
+
+	# Build a separate multi-arch image index and push it unsigned (negative case)
+	printf 'FROM ${ALPINE_IMAGE}\nCMD ["echo", "notation multiarch unsigned image"]' > .staging/notation/multiarch/Dockerfile
+	docker buildx create --use
+	docker buildx build --platform linux/amd64,linux/arm64 --output type=oci,dest=.staging/notation/multiarch/multiarch.tar -t notation-multiarch:v0 .staging/notation/multiarch
+	${GITHUB_WORKSPACE}/bin/oras cp --from-oci-layout .staging/notation/multiarch/multiarch.tar:v0 ${TEST_REGISTRY}/notation:multiarch-unsigned
+	rm .staging/notation/multiarch/multiarch.tar
+
+	# Sign the image index digest with the default notation test key
+	NOTATION_EXPERIMENTAL=1 .staging/notation/notation sign --allow-referrers-api -u ${TEST_REGISTRY_USERNAME} -p ${TEST_REGISTRY_PASSWORD} ${TEST_REGISTRY}/notation@`${GITHUB_WORKSPACE}/bin/oras manifest fetch ${TEST_REGISTRY}/notation:multiarch-signed --descriptor | jq .digest | xargs`
 	python3 ./scripts/crl_server.py & echo "started crl server"
 
 e2e-cosign-setup:

--- a/internal/executor/executor_benchmark_test.go
+++ b/internal/executor/executor_benchmark_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package executor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/notaryproject/ratify-go"
+
+	"github.com/notaryproject/ratify/v2/internal/policyenforcer"
+	"github.com/notaryproject/ratify/v2/internal/store"
+	"github.com/notaryproject/ratify/v2/internal/verifier"
+)
+
+// benchScopedExecutor returns a ScopedExecutor populated with executors for
+// each scope tier, used by the routing benchmarks below.
+func benchScopedExecutor() *ScopedExecutor {
+	return &ScopedExecutor{
+		wildcard: map[string]*ratify.Executor{
+			"example.com": {},
+		},
+		registry: map[string]*ratify.Executor{
+			"registry.example.com": {},
+		},
+		repository: map[string]*ratify.Executor{
+			"registry.example.com/repository/foo": {},
+		},
+	}
+}
+
+// BenchmarkMatchExecutor measures the scope-routing hot path that runs on every
+// validation request. Each sub-benchmark targets a different precedence tier
+// (repository, registry, wildcard) plus the no-match failure path.
+func BenchmarkMatchExecutor(b *testing.B) {
+	scopedExecutor := benchScopedExecutor()
+	cases := []struct {
+		name     string
+		artifact string
+	}{
+		{"repository", "registry.example.com/repository/foo:v1"},
+		{"registry", "registry.example.com/foo:v1"},
+		{"wildcard", "foo.example.com/bar:v1"},
+		{"no-match", "unknown.com/foo:v1"},
+	}
+	for _, c := range cases {
+		b.Run(c.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				//nolint:errcheck // error path is intentionally exercised by the no-match case
+				_, _ = scopedExecutor.matchExecutor(c.artifact)
+			}
+		})
+	}
+}
+
+// BenchmarkValidateArtifact measures the end-to-end validation path through a
+// fully wired ScopedExecutor backed by the in-package mocks (store, verifier
+// and policy enforcer). It is intended as an observability signal for the
+// whole request flow and is intentionally NOT part of the regression gate,
+// since its result depends on mock behavior rather than a single hot function.
+func BenchmarkValidateArtifact(b *testing.B) {
+	registerMocks()
+
+	scopedExecutor, err := NewScopedExecutor(Options{
+		Executors: []ScopedOptions{
+			{
+				Scopes: []string{"test"},
+				Verifiers: []verifier.NewOptions{
+					{
+						Name: mockVerifierName,
+						Type: mockVerifierType,
+					},
+				},
+				Stores: []store.NewOptions{
+					{
+						Type:   mockStoreType,
+						Scopes: []string{"test"},
+					},
+				},
+				Policy: &policyenforcer.NewOptions{
+					Type: mockPolicyEnforcerType,
+				},
+			},
+		},
+	})
+	if err != nil {
+		b.Fatalf("failed to create scoped executor: %v", err)
+	}
+
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		//nolint:errcheck // the mock validation result/error is not asserted in a benchmark
+		_, _ = scopedExecutor.ValidateArtifact(ctx, "test/foo:v1")
+	}
+}

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -17,6 +17,7 @@ package executor
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/notaryproject/ratify-go"
@@ -479,11 +480,18 @@ func registerForBenchmark() {
 	tryRegister(func() { policyenforcer.Register(mockPolicyEnforcerType, createPolicyEnforcer) })
 }
 
-// tryRegister runs a registration func, swallowing the panic raised when the
-// type is already registered.
+// tryRegister runs a registration func, swallowing only the panic raised when
+// the type is already registered (the factory Register functions panic with a
+// message containing "already registered"). Any other panic indicates a real
+// setup problem and is re-raised so the benchmark fails loudly.
 func tryRegister(register func()) {
 	defer func() {
-		_ = recover()
+		if r := recover(); r != nil {
+			if msg, ok := r.(string); ok && strings.Contains(msg, "already registered") {
+				return
+			}
+			panic(r)
+		}
 	}()
 	register()
 }

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -17,8 +17,7 @@ package executor
 
 import (
 	"context"
-	"fmt"
-	"strings"
+	"sync"
 	"testing"
 
 	"github.com/notaryproject/ratify-go"
@@ -89,9 +88,7 @@ func createMockVerifier(_ verifier.NewOptions, _ []string) (ratify.Verifier, err
 }
 
 func TestNewExecutor(t *testing.T) {
-	store.Register(mockStoreType, newMockStore)
-	verifier.Register(mockVerifierType, createMockVerifier)
-	policyenforcer.Register(mockPolicyEnforcerType, createPolicyEnforcer)
+	registerMocks()
 
 	tests := []struct {
 		name           string
@@ -471,32 +468,22 @@ func BenchmarkMatchExecutor(b *testing.B) {
 	}
 }
 
-// registerForBenchmark registers the in-package mocks, tolerating the case
-// where another test in this package has already registered the same types.
-// The underlying Register functions panic on duplicate registration, so each
-// call is guarded with a recover.
-func registerForBenchmark() {
-	tryRegister(func() { store.Register(mockStoreType, newMockStore) })
-	tryRegister(func() { verifier.Register(mockVerifierType, createMockVerifier) })
-	tryRegister(func() { policyenforcer.Register(mockPolicyEnforcerType, createPolicyEnforcer) })
-}
+// registerMocksOnce guards the one-time registration of the in-package mocks.
+// The underlying factory Register functions panic on duplicate registration,
+// so all callers (tests and benchmarks) funnel through registerMocks to ensure
+// the mocks are registered exactly once per test binary.
+var registerMocksOnce sync.Once
 
-// tryRegister runs a registration func, swallowing only the panic raised when
-// the type is already registered (the factory Register functions panic with a
-// message containing "already registered"). The recovered value may be a
-// string or an error, so it is normalized with fmt.Sprint before inspection.
-// Any other panic indicates a real setup problem and is re-raised so the
-// benchmark fails loudly.
-func tryRegister(register func()) {
-	defer func() {
-		if r := recover(); r != nil {
-			if strings.Contains(fmt.Sprint(r), "already registered") {
-				return
-			}
-			panic(r)
-		}
-	}()
-	register()
+// registerMocks registers the in-package store, verifier and policy-enforcer
+// mocks exactly once, regardless of how many tests or benchmark iterations
+// invoke it. Using sync.Once avoids relying on recover/panic-message matching
+// to tolerate duplicate registration.
+func registerMocks() {
+	registerMocksOnce.Do(func() {
+		store.Register(mockStoreType, newMockStore)
+		verifier.Register(mockVerifierType, createMockVerifier)
+		policyenforcer.Register(mockPolicyEnforcerType, createPolicyEnforcer)
+	})
 }
 
 // BenchmarkValidateArtifact measures the end-to-end validation path through a
@@ -505,7 +492,7 @@ func tryRegister(register func()) {
 // whole request flow and is intentionally NOT part of the regression gate,
 // since its result depends on mock behavior rather than a single hot function.
 func BenchmarkValidateArtifact(b *testing.B) {
-	registerForBenchmark()
+	registerMocks()
 
 	scopedExecutor, err := NewScopedExecutor(Options{
 		Executors: []ScopedOptions{

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -427,3 +427,106 @@ func TestResolve(t *testing.T) {
 		t.Error("expected no error for valid artifact with wildcard scope, got:", err)
 	}
 }
+
+// benchScopedExecutor returns a ScopedExecutor populated with executors for
+// each scope tier, used by the routing benchmarks below.
+func benchScopedExecutor() *ScopedExecutor {
+	return &ScopedExecutor{
+		wildcard: map[string]*ratify.Executor{
+			"example.com": {},
+		},
+		registry: map[string]*ratify.Executor{
+			"registry.example.com": {},
+		},
+		repository: map[string]*ratify.Executor{
+			"registry.example.com/repository/foo": {},
+		},
+	}
+}
+
+// BenchmarkMatchExecutor measures the scope-routing hot path that runs on every
+// validation request. Each sub-benchmark targets a different precedence tier
+// (repository, registry, wildcard) plus the no-match failure path.
+func BenchmarkMatchExecutor(b *testing.B) {
+	scopedExecutor := benchScopedExecutor()
+	cases := []struct {
+		name     string
+		artifact string
+	}{
+		{"repository", "registry.example.com/repository/foo:v1"},
+		{"registry", "registry.example.com/foo:v1"},
+		{"wildcard", "foo.example.com/bar:v1"},
+		{"no-match", "unknown.com/foo:v1"},
+	}
+	for _, c := range cases {
+		b.Run(c.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				//nolint:errcheck // error path is intentionally exercised by the no-match case
+				_, _ = scopedExecutor.matchExecutor(c.artifact)
+			}
+		})
+	}
+}
+
+// registerForBenchmark registers the in-package mocks, tolerating the case
+// where another test in this package has already registered the same types.
+// The underlying Register functions panic on duplicate registration, so each
+// call is guarded with a recover.
+func registerForBenchmark() {
+	tryRegister(func() { store.Register(mockStoreType, newMockStore) })
+	tryRegister(func() { verifier.Register(mockVerifierType, createMockVerifier) })
+	tryRegister(func() { policyenforcer.Register(mockPolicyEnforcerType, createPolicyEnforcer) })
+}
+
+// tryRegister runs a registration func, swallowing the panic raised when the
+// type is already registered.
+func tryRegister(register func()) {
+	defer func() {
+		_ = recover()
+	}()
+	register()
+}
+
+// BenchmarkValidateArtifact measures the end-to-end validation path through a
+// fully wired ScopedExecutor backed by the in-package mocks (store, verifier
+// and policy enforcer). It is intended as an observability signal for the
+// whole request flow and is intentionally NOT part of the regression gate,
+// since its result depends on mock behavior rather than a single hot function.
+func BenchmarkValidateArtifact(b *testing.B) {
+	registerForBenchmark()
+
+	scopedExecutor, err := NewScopedExecutor(Options{
+		Executors: []ScopedOptions{
+			{
+				Scopes: []string{"test"},
+				Verifiers: []verifier.NewOptions{
+					{
+						Name: mockVerifierName,
+						Type: mockVerifierType,
+					},
+				},
+				Stores: []store.NewOptions{
+					{
+						Type:   mockStoreType,
+						Scopes: []string{"test"},
+					},
+				},
+				Policy: &policyenforcer.NewOptions{
+					Type: mockPolicyEnforcerType,
+				},
+			},
+		},
+	})
+	if err != nil {
+		b.Fatalf("failed to create scoped executor: %v", err)
+	}
+
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		//nolint:errcheck // the mock validation result/error is not asserted in a benchmark
+		_, _ = scopedExecutor.ValidateArtifact(ctx, "test/foo:v1")
+	}
+}

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -427,47 +427,6 @@ func TestResolve(t *testing.T) {
 	}
 }
 
-// benchScopedExecutor returns a ScopedExecutor populated with executors for
-// each scope tier, used by the routing benchmarks below.
-func benchScopedExecutor() *ScopedExecutor {
-	return &ScopedExecutor{
-		wildcard: map[string]*ratify.Executor{
-			"example.com": {},
-		},
-		registry: map[string]*ratify.Executor{
-			"registry.example.com": {},
-		},
-		repository: map[string]*ratify.Executor{
-			"registry.example.com/repository/foo": {},
-		},
-	}
-}
-
-// BenchmarkMatchExecutor measures the scope-routing hot path that runs on every
-// validation request. Each sub-benchmark targets a different precedence tier
-// (repository, registry, wildcard) plus the no-match failure path.
-func BenchmarkMatchExecutor(b *testing.B) {
-	scopedExecutor := benchScopedExecutor()
-	cases := []struct {
-		name     string
-		artifact string
-	}{
-		{"repository", "registry.example.com/repository/foo:v1"},
-		{"registry", "registry.example.com/foo:v1"},
-		{"wildcard", "foo.example.com/bar:v1"},
-		{"no-match", "unknown.com/foo:v1"},
-	}
-	for _, c := range cases {
-		b.Run(c.name, func(b *testing.B) {
-			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
-				//nolint:errcheck // error path is intentionally exercised by the no-match case
-				_, _ = scopedExecutor.matchExecutor(c.artifact)
-			}
-		})
-	}
-}
-
 // registerMocksOnce guards the one-time registration of the in-package mocks.
 // The underlying factory Register functions panic on duplicate registration,
 // so all callers (tests and benchmarks) funnel through registerMocks to ensure
@@ -484,47 +443,4 @@ func registerMocks() {
 		verifier.Register(mockVerifierType, createMockVerifier)
 		policyenforcer.Register(mockPolicyEnforcerType, createPolicyEnforcer)
 	})
-}
-
-// BenchmarkValidateArtifact measures the end-to-end validation path through a
-// fully wired ScopedExecutor backed by the in-package mocks (store, verifier
-// and policy enforcer). It is intended as an observability signal for the
-// whole request flow and is intentionally NOT part of the regression gate,
-// since its result depends on mock behavior rather than a single hot function.
-func BenchmarkValidateArtifact(b *testing.B) {
-	registerMocks()
-
-	scopedExecutor, err := NewScopedExecutor(Options{
-		Executors: []ScopedOptions{
-			{
-				Scopes: []string{"test"},
-				Verifiers: []verifier.NewOptions{
-					{
-						Name: mockVerifierName,
-						Type: mockVerifierType,
-					},
-				},
-				Stores: []store.NewOptions{
-					{
-						Type:   mockStoreType,
-						Scopes: []string{"test"},
-					},
-				},
-				Policy: &policyenforcer.NewOptions{
-					Type: mockPolicyEnforcerType,
-				},
-			},
-		},
-	})
-	if err != nil {
-		b.Fatalf("failed to create scoped executor: %v", err)
-	}
-
-	ctx := context.Background()
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		//nolint:errcheck // the mock validation result/error is not asserted in a benchmark
-		_, _ = scopedExecutor.ValidateArtifact(ctx, "test/foo:v1")
-	}
 }

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -17,6 +17,7 @@ package executor
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -482,12 +483,14 @@ func registerForBenchmark() {
 
 // tryRegister runs a registration func, swallowing only the panic raised when
 // the type is already registered (the factory Register functions panic with a
-// message containing "already registered"). Any other panic indicates a real
-// setup problem and is re-raised so the benchmark fails loudly.
+// message containing "already registered"). The recovered value may be a
+// string or an error, so it is normalized with fmt.Sprint before inspection.
+// Any other panic indicates a real setup problem and is re-raised so the
+// benchmark fails loudly.
 func tryRegister(register func()) {
 	defer func() {
 		if r := recover(); r != nil {
-			if msg, ok := r.(string); ok && strings.Contains(msg, "already registered") {
+			if strings.Contains(fmt.Sprint(r), "already registered") {
 				return
 			}
 			panic(r)

--- a/scripts/benchmark-gate.sh
+++ b/scripts/benchmark-gate.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Copyright The Ratify Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# benchmark-gate.sh fails when a benchmark regresses beyond a threshold.
+#
+# It compares two raw `go test -bench` result files using benchstat and then
+# inspects the "vs base" delta column. Any statistically-significant increase
+# (worse sec/op, B/op, or allocs/op) above THRESHOLD_PCT fails the gate.
+#
+# Usage:
+#   scripts/benchmark-gate.sh <base.txt> <head.txt> [threshold_pct]
+#
+# Environment:
+#   THRESHOLD_PCT  Maximum allowed regression percentage (default: 20).
+#   EXCLUDE_PATTERN  Extended regex of benchmark row names to exclude from the
+#                    gate (e.g. observability-only benchmarks). Excluded rows
+#                    still appear in the printed comparison but never fail the
+#                    gate. Default: "ValidateArtifact".
+
+set -euo pipefail
+
+BASE_FILE="${1:?usage: benchmark-gate.sh <base.txt> <head.txt> [threshold_pct]}"
+HEAD_FILE="${2:?usage: benchmark-gate.sh <base.txt> <head.txt> [threshold_pct]}"
+THRESHOLD_PCT="${3:-${THRESHOLD_PCT:-20}}"
+EXCLUDE_PATTERN="${EXCLUDE_PATTERN:-ValidateArtifact}"
+
+if ! command -v benchstat >/dev/null 2>&1; then
+  echo "benchstat not found on PATH. Install with: go install golang.org/x/perf/cmd/benchstat@latest" >&2
+  exit 2
+fi
+
+COMPARISON="$(benchstat "${BASE_FILE}" "${HEAD_FILE}")"
+
+echo "## Benchmark comparison (threshold: +${THRESHOLD_PCT}%)"
+echo '```'
+echo "${COMPARISON}"
+echo '```'
+
+# Parse the "vs base" delta column. benchstat prints deltas like "+21.34%" or
+# "-5.10%"; "~" means the change was not statistically significant. We flag any
+# positive delta (a regression for sec/op, B/op and allocs/op) above threshold.
+# Rows whose name matches EXCLUDE_PATTERN are skipped (non-gating signals).
+regressions="$(
+  awk -v threshold="${THRESHOLD_PCT}" -v exclude="${EXCLUDE_PATTERN}" '
+    match($0, /[+][0-9]+(\.[0-9]+)?%/) {
+      # Skip the geomean aggregate row: it is a summary across all benchmarks
+      # (including excluded ones), not an individual result to gate on.
+      if ($1 == "geomean") {
+        next
+      }
+      if (exclude != "" && $1 ~ exclude) {
+        next
+      }
+      pct = substr($0, RSTART + 1, RLENGTH - 2) + 0
+      if (pct > threshold) {
+        print "  - " $1 ": +" pct "% (limit +" threshold "%)"
+      }
+    }
+  ' <<<"${COMPARISON}"
+)"
+
+if [[ -n "${regressions}" ]]; then
+  echo ""
+  echo "Benchmark regressions detected:" >&2
+  echo "${regressions}" >&2
+  exit 1
+fi
+
+echo ""
+echo "No benchmark regressions above +${THRESHOLD_PCT}%."

--- a/scripts/benchmark-gate.sh
+++ b/scripts/benchmark-gate.sh
@@ -19,7 +19,7 @@
 # (worse sec/op, B/op, or allocs/op) above THRESHOLD_PCT fails the gate.
 #
 # Usage:
-#   scripts/benchmark-gate.sh <base.txt> <head.txt> [threshold_pct]
+#   scripts/benchmark-gate.sh <benchmark-base.txt> <benchmark-head.txt> [threshold_pct]
 #
 # Environment:
 #   THRESHOLD_PCT  Maximum allowed regression percentage (default: 20).
@@ -37,8 +37,8 @@ set -euo pipefail
 export LC_ALL=C
 export LANG=C
 
-BASE_FILE="${1:?usage: benchmark-gate.sh <base.txt> <head.txt> [threshold_pct]}"
-HEAD_FILE="${2:?usage: benchmark-gate.sh <base.txt> <head.txt> [threshold_pct]}"
+BASE_FILE="${1:?usage: benchmark-gate.sh <benchmark-base.txt> <benchmark-head.txt> [threshold_pct]}"
+HEAD_FILE="${2:?usage: benchmark-gate.sh <benchmark-base.txt> <benchmark-head.txt> [threshold_pct]}"
 THRESHOLD_PCT="${3:-${THRESHOLD_PCT:-20}}"
 EXCLUDE_PATTERN="${EXCLUDE_PATTERN:-ValidateArtifact}"
 BENCHSTAT_VERSION="${BENCHSTAT_VERSION:-v0.0.0-20260512194132-3cf34090a3db}"

--- a/scripts/benchmark-gate.sh
+++ b/scripts/benchmark-gate.sh
@@ -48,15 +48,34 @@ echo "${COMPARISON}"
 echo '```'
 
 # Parse the "vs base" delta column. benchstat prints deltas like "+21.34%" or
-# "-5.10%"; "~" means the change was not statistically significant. We flag any
-# positive delta (a regression for sec/op, B/op and allocs/op) above threshold.
-# Rows whose name matches EXCLUDE_PATTERN are skipped (non-gating signals).
+# "-5.10%"; "~" means the change was not statistically significant.
+#
+# The gate is unit-aware: benchstat groups results by metric and prints the unit
+# in each section's "vs base" header (e.g. sec/op, B/op, allocs/op, MB/s). For
+# "lower-is-better" units (anything ending in /op) a positive delta is a
+# regression; for "higher-is-better" throughput units (ending in /s, e.g. MB/s
+# from b.SetBytes) a negative delta is the regression instead. Rows whose name
+# matches EXCLUDE_PATTERN are skipped (non-gating signals).
 regressions="$(
   awk -v threshold="${THRESHOLD_PCT}" -v exclude="${EXCLUDE_PATTERN}" '
-    # Match a positive delta: either a finite "+12.34%" or "+Inf%". benchstat
-    # emits +Inf% when the base metric is 0 and the head metric is > 0 (e.g.
-    # allocs/op going from 0 to non-zero), which is always a real regression.
-    match($0, /[+]([0-9]+(\.[0-9]+)?|Inf)%/) {
+    # Track the current metric/unit from each section'"'"'s "vs base" header so we
+    # know which direction counts as a regression for the rows that follow.
+    /vs base/ {
+      unit = ""
+      for (i = 1; i <= NF; i++) {
+        if ($i ~ /\/(op|s)$/) {
+          unit = $i
+          break
+        }
+      }
+      # Throughput units (MB/s, B/s, op/s) are better when higher.
+      higher_is_better = (unit ~ /\/s$/)
+      next
+    }
+    # Match a signed delta: a finite "+12.34%"/"-5.10%" or "+Inf%"/"-Inf%".
+    # benchstat emits +Inf% when the base metric is 0 and the head metric is > 0
+    # (e.g. allocs/op going from 0 to non-zero).
+    match($0, /[+-]([0-9]+(\.[0-9]+)?|Inf)%/) {
       # Skip the geomean aggregate row: it is a summary across all benchmarks
       # (including excluded ones), not an individual result to gate on.
       if ($1 == "geomean") {
@@ -65,14 +84,27 @@ regressions="$(
       if (exclude != "" && $1 ~ exclude) {
         next
       }
+      sign = substr($0, RSTART, 1)
       delta = substr($0, RSTART + 1, RLENGTH - 2)
+      # A regression is an increase for lower-is-better units and a decrease for
+      # higher-is-better units; the opposite direction is an improvement.
+      if (higher_is_better) {
+        if (sign != "-") {
+          next
+        }
+      } else {
+        if (sign != "+") {
+          next
+        }
+      }
+      label = (unit != "") ? $1 " (" unit ")" : $1
       if (delta == "Inf") {
-        print "  - " $1 ": +Inf% (limit +" threshold "%)"
+        print "  - " label ": " sign "Inf% (limit " threshold "%)"
         next
       }
       pct = delta + 0
       if (pct > threshold) {
-        print "  - " $1 ": +" pct "% (limit +" threshold "%)"
+        print "  - " label ": " sign pct "% (limit " threshold "%)"
       }
     }
   ' <<<"${COMPARISON}"

--- a/scripts/benchmark-gate.sh
+++ b/scripts/benchmark-gate.sh
@@ -27,6 +27,8 @@
 #                    gate (e.g. observability-only benchmarks). Excluded rows
 #                    still appear in the printed comparison but never fail the
 #                    gate. Default: "ValidateArtifact".
+#   BENCHSTAT_VERSION  Version of benchstat to auto-install when it is not
+#                    already on PATH. Default: a pinned pseudo-version.
 
 set -euo pipefail
 
@@ -39,10 +41,17 @@ BASE_FILE="${1:?usage: benchmark-gate.sh <base.txt> <head.txt> [threshold_pct]}"
 HEAD_FILE="${2:?usage: benchmark-gate.sh <base.txt> <head.txt> [threshold_pct]}"
 THRESHOLD_PCT="${3:-${THRESHOLD_PCT:-20}}"
 EXCLUDE_PATTERN="${EXCLUDE_PATTERN:-ValidateArtifact}"
+BENCHSTAT_VERSION="${BENCHSTAT_VERSION:-v0.0.0-20260512194132-3cf34090a3db}"
 
+# Install benchstat on demand so the gate works out of the box locally and in
+# CI. The version is pinned for deterministic, reproducible comparisons.
 if ! command -v benchstat >/dev/null 2>&1; then
-  echo "benchstat not found on PATH. Install with: go install golang.org/x/perf/cmd/benchstat@latest" >&2
-  exit 2
+  echo "benchstat not found on PATH; installing golang.org/x/perf/cmd/benchstat@${BENCHSTAT_VERSION}" >&2
+  if ! go install "golang.org/x/perf/cmd/benchstat@${BENCHSTAT_VERSION}"; then
+    echo "failed to install benchstat" >&2
+    exit 2
+  fi
+  export PATH="$PATH:$(go env GOPATH)/bin"
 fi
 
 COMPARISON="$(benchstat "${BASE_FILE}" "${HEAD_FILE}")"

--- a/scripts/benchmark-gate.sh
+++ b/scripts/benchmark-gate.sh
@@ -53,7 +53,10 @@ echo '```'
 # Rows whose name matches EXCLUDE_PATTERN are skipped (non-gating signals).
 regressions="$(
   awk -v threshold="${THRESHOLD_PCT}" -v exclude="${EXCLUDE_PATTERN}" '
-    match($0, /[+][0-9]+(\.[0-9]+)?%/) {
+    # Match a positive delta: either a finite "+12.34%" or "+Inf%". benchstat
+    # emits +Inf% when the base metric is 0 and the head metric is > 0 (e.g.
+    # allocs/op going from 0 to non-zero), which is always a real regression.
+    match($0, /[+]([0-9]+(\.[0-9]+)?|Inf)%/) {
       # Skip the geomean aggregate row: it is a summary across all benchmarks
       # (including excluded ones), not an individual result to gate on.
       if ($1 == "geomean") {
@@ -62,7 +65,12 @@ regressions="$(
       if (exclude != "" && $1 ~ exclude) {
         next
       }
-      pct = substr($0, RSTART + 1, RLENGTH - 2) + 0
+      delta = substr($0, RSTART + 1, RLENGTH - 2)
+      if (delta == "Inf") {
+        print "  - " $1 ": +Inf% (limit +" threshold "%)"
+        next
+      }
+      pct = delta + 0
       if (pct > threshold) {
         print "  - " $1 ": +" pct "% (limit +" threshold "%)"
       }

--- a/scripts/benchmark-gate.sh
+++ b/scripts/benchmark-gate.sh
@@ -30,6 +30,11 @@
 
 set -euo pipefail
 
+# Force a deterministic, C locale so benchstat output and awk numeric parsing
+# use '.' as the decimal separator regardless of the host's locale settings.
+export LC_ALL=C
+export LANG=C
+
 BASE_FILE="${1:?usage: benchmark-gate.sh <base.txt> <head.txt> [threshold_pct]}"
 HEAD_FILE="${2:?usage: benchmark-gate.sh <base.txt> <head.txt> [threshold_pct]}"
 THRESHOLD_PCT="${3:-${THRESHOLD_PCT:-20}}"


### PR DESCRIPTION
## Description

Adds a performance-testing tier to the repo so benchmark regressions are caught in CI.

### Changes
- **Makefile**: new `benchmark` target running `go test -run='^$' -bench=. -benchmem -count=$(BENCH_COUNT) ./...` (configurable via `BENCH_COUNT` / `BENCH_OUT`).
- **scripts/benchmark-gate.sh**: compares base vs head results with `benchstat` and fails when a benchmark regresses beyond `THRESHOLD_PCT` (default 20%). Supports `EXCLUDE_PATTERN` for non-gating benchmarks and always skips the `geomean` aggregate row.
- **.github/workflows/benchmark.yml**: runs benchmarks on PRs, benchmarks the merge base via `git worktree`, runs the gate, and writes the comparison to the job summary. On pushes to `main` it records results without gating. Uses pinned action SHAs + hardened runner to match existing workflows.
- **internal/executor**: two benchmarks for the validation path:
  - `BenchmarkMatchExecutor` — gating; the deterministic scope-routing hot path that runs on every request.
  - `BenchmarkValidateArtifact` — non-gating observability signal; end-to-end flow through a mock-backed `ScopedExecutor` (excluded from the gate).
- **.gitignore**: ignore generated `bench.txt` / `head.txt` / `base.txt`.

### Validation
- `make benchmark` runs the existing + new benchmarks successfully.
- `go vet ./internal/executor/` is clean.
- Gate script verified for pass (no regression / excluded row / geomean) and fail (real regression in a gating benchmark) paths.

### Notes
- The gate only protects code that has benchmarks; today that's the credential-provider package plus the new executor routing benchmark. Future PRs can extend coverage to more hot paths.
- GitHub-hosted runners are shared and noisy; the 20% threshold + `count=10` reduces false positives.