### PR TITLE
chore: update Go version to 1.26.4

### DIFF
--- a/.github/workflows/scan-vulns.yaml
+++ b/.github/workflows/scan-vulns.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
-          go-version: "1.26"
+          go-version: "1.26.4"
           check-latest: true
       - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
         with:

--- a/httpserver/Dockerfile
+++ b/httpserver/Dockerfile
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM golang:1.26.3@sha256:2981696eed011d747340d7252620932677929cce7d2d539602f56a8d7e9b660b AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4@sha256:68cb6d68bed024785b69195b89af7ac7a444f27791435f98647edff595aa0479 AS builder
 
 ARG TARGETPLATFORM
 ARG TARGETOS
@@ -60,4 +60,3 @@ EXPOSE 8888
 USER 65532:65532
 
 ENTRYPOINT ["/app/ratify", "serve", "--http", ":6001"]
-


### PR DESCRIPTION
## Summary

Update Go usage to 1.26.4 only where it affects vulnerability scanning or published image builds.

## Motivation

Go 1.26.4 includes fixes for the Go standard library vulnerabilities reported by govulncheck:

- GO-2026-5037 / CVE-2026-27145
- GO-2026-5038 / CVE-2026-42504
- GO-2026-5039 / CVE-2026-42507

Updating only the govulncheck workflow is not sufficient because GHCR-published Ratify images are built by Dockerfile builder stages. If the Dockerfile still uses Go 1.26.3, the resulting binary is still built with the vulnerable Go standard library.

## Changes

- Update `scan-vulns` govulncheck toolchain to Go 1.26.4
- Update Docker builder image to Go 1.26.4 with pinned digest
- Keep `go.mod` unchanged
- Keep CI workflows that previously used minor-only Go versions (for example `1.26`) minor-only; update only workflow references that were already patch-pinned to `1.26.3`

## Validation

- Confirmed the final PR diff does not modify `go.mod`.
- Confirmed Dockerfile builder image references Go 1.26.4.