### PR TITLE
chore: update Go version to 1.26.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup go environment
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
       - name: Run unit tests
         run: make test
       - name: Upload coverage to codecov.io

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0

--- a/.github/workflows/scan-vulns.yaml
+++ b/.github/workflows/scan-vulns.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
           check-latest: true
       - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM golang:1.26.3-alpine3.23@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine3.23@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

Update Go usage to 1.26.4 only where it affects vulnerability scanning or published image builds.

## Motivation

Go 1.26.4 includes fixes for the Go standard library vulnerabilities reported by govulncheck:

- GO-2026-5037 / CVE-2026-27145
- GO-2026-5038 / CVE-2026-42504
- GO-2026-5039 / CVE-2026-42507

Updating only the govulncheck workflow is not sufficient because GHCR-published Ratify images are built by Dockerfile builder stages. If the Dockerfile still uses Go 1.26.3, the resulting binary is still built with the vulnerable Go standard library.

## Changes

- Update `scan-vulns` govulncheck toolchain to Go 1.26.4
- Update Docker builder image to Go 1.26.4 with pinned digest
- Keep `go.mod` unchanged
- Keep CI workflows that previously used minor-only Go versions (for example `1.26`) minor-only; update only workflow references that were already patch-pinned to `1.26.3`

## Validation

- Confirmed the final PR diff does not modify `go.mod`.
- Confirmed Dockerfile builder image references Go 1.26.4.