### PR TITLE
feat: add stores[].plainHttp for HTTP registries

### DIFF
--- a/deployments/ratify-gatekeeper-provider/templates/executor.yaml
+++ b/deployments/ratify-gatekeeper-provider/templates/executor.yaml
@@ -30,6 +30,9 @@ spec:
           username: "{{ .credential.username }}"
           password: "{{ .credential.password }}"
           {{- end }}
+        {{- if .plainHttp }}
+        plainHttp: true
+        {{- end }}
         {{- if eq (include "ratify.cosignConfigured" $root) "true" }}
         allowCosignTag: true
         {{- end }}

--- a/deployments/ratify-gatekeeper-provider/templates/executor.yaml
+++ b/deployments/ratify-gatekeeper-provider/templates/executor.yaml
@@ -31,7 +31,17 @@ spec:
           password: "{{ .credential.password }}"
           {{- end }}
         {{- if .plainHttp }}
+        {{- if or .caBase64 .caPem }}
+        {{- fail (printf "store with scopes %v: plainHttp cannot be combined with caBase64/caPem (no TLS over plain HTTP)" .scopes) }}
+        {{- end }}
         plainHttp: true
+        {{- else }}
+        {{- if .caPem }}
+        caPem: {{ .caPem | quote }}
+        {{- end }}
+        {{- if .caBase64 }}
+        caBase64: {{ .caBase64 | quote }}
+        {{- end }}
         {{- end }}
         {{- if eq (include "ratify.cosignConfigured" $root) "true" }}
         allowCosignTag: true

--- a/deployments/ratify-gatekeeper-provider/values.yaml
+++ b/deployments/ratify-gatekeeper-provider/values.yaml
@@ -43,6 +43,7 @@ cosign:
 
 stores:
   - scopes: []
+    plainHttp: false # set to true for registries that do not use TLS (e.g. local development)
     caBase64: "" # base64 encoded CA certificate, used for TLS verification, e.g. "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCg=="
     caPem: "" # PEM encoded CA certificate, used for TLS verification, e.g. "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----"
     # if both caBase64 and caPem are provided, caPem will be used


### PR DESCRIPTION
## Summary

Adds an opt-in `plainHttp` toggle on each store in the `ratify-gatekeeper-provider` Helm chart so the rendered `Executor` CR can talk to registries that do not serve TLS (e.g. local kind clusters and dev registries).

## Changes

- `deployments/ratify-gatekeeper-provider/values.yaml` — new `stores[].plainHttp` field (defaults to `false`)
- `deployments/ratify-gatekeeper-provider/templates/executor.yaml` — render `plainHttp: true` on the store when the value is set

## Backwards compatibility

Default is `false`, so existing deployments render exactly the same Executor as before.

## Motivation

Needed by the upcoming v2 Executor CRD e2e workflow which uses a local insecure registry. Split out of #2565 so it can land independently.

## Testing

`helm template` of the chart with and without `--set stores[0].plainHttp=true` renders the expected diff.