### PR TITLE
fix: initialize registryHostGetter in MIAuthProvider to prevent nil pointer panic

### DIFF
--- a/pkg/common/oras/authprovider/azure/azureidentity.go
+++ b/pkg/common/oras/authprovider/azure/azureidentity.go
@@ -44,6 +44,9 @@ func (g *defaultManagedIdentityTokenGetterImpl) GetManagedIdentityToken(ctx cont
 	return getManagedIdentityToken(ctx, clientID, azidentity.NewManagedIdentityCredential)
 }
 
+// getManagedIdentityTokenFunc is a package-level variable to allow test injection.
+var getManagedIdentityTokenFunc = getManagedIdentityToken
+
 func getManagedIdentityToken(ctx context.Context, clientID string, newCredentialFunc func(opts *azidentity.ManagedIdentityCredentialOptions) (*azidentity.ManagedIdentityCredential, error)) (azcore.AccessToken, error) {
 	id := azidentity.ClientID(clientID)
 	opts := azidentity.ManagedIdentityCredentialOptions{ID: id}
@@ -115,7 +118,7 @@ func (s *azureManagedIdentityProviderFactory) Create(authProviderConfig provider
 	}
 
 	// retrieve an AAD Access token
-	token, err := getManagedIdentityToken(context.Background(), client, azidentity.NewManagedIdentityCredential)
+	token, err := getManagedIdentityTokenFunc(context.Background(), client, azidentity.NewManagedIdentityCredential)
 	if err != nil {
 		return nil, re.ErrorCodeAuthDenied.NewError(re.AuthProvider, "", re.AzureManagedIdentityLink, err, "", re.HideStackTrace)
 	}
@@ -125,6 +128,7 @@ func (s *azureManagedIdentityProviderFactory) Create(authProviderConfig provider
 		clientID:                client,
 		tenantID:                tenant,
 		authClientFactory:       &defaultAuthClientFactoryImpl{},          // Concrete implementation
+		registryHostGetter:      &defaultRegistryHostGetterImpl{},         // Concrete implementation
 		getManagedIdentityToken: &defaultManagedIdentityTokenGetterImpl{}, // Concrete implementation
 		endpoints:               endpoints,
 	}, nil

--- a/pkg/common/oras/authprovider/azure/azureidentity_test.go
+++ b/pkg/common/oras/authprovider/azure/azureidentity_test.go
@@ -272,3 +272,27 @@ func TestGetManagedIdentityToken_Error(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, azcore.AccessToken{}, token)
 }
+
+// TestMIAuthProvider_Create_InitializesRegistryHostGetter verifies that the
+// factory function initializes registryHostGetter, preventing nil pointer
+// dereference panics in Provide(). See https://github.com/notaryproject/ratify/issues/2504
+func TestMIAuthProvider_Create_InitializesRegistryHostGetter(t *testing.T) {
+	t.Setenv("AZURE_TENANT_ID", "test-tenant")
+	t.Setenv("AZURE_CLIENT_ID", "test-client")
+
+	// Mock the token acquisition to avoid real Azure calls in CI
+	originalFunc := getManagedIdentityTokenFunc
+	getManagedIdentityTokenFunc = func(_ context.Context, _ string, _ func(opts *azidentity.ManagedIdentityCredentialOptions) (*azidentity.ManagedIdentityCredential, error)) (azcore.AccessToken, error) {
+		return azcore.AccessToken{Token: "fake-token", ExpiresOn: time.Now().Add(1 * time.Hour)}, nil
+	}
+	defer func() { getManagedIdentityTokenFunc = originalFunc }()
+
+	factory := &azureManagedIdentityProviderFactory{}
+	p, err := factory.Create(authprovider.AuthProviderConfig{})
+	assert.NoError(t, err)
+	assert.NotNil(t, p)
+
+	miProvider, ok := p.(*MIAuthProvider)
+	assert.True(t, ok)
+	assert.NotNil(t, miProvider.registryHostGetter, "registryHostGetter must be initialized to prevent nil pointer panic in Provide()")
+}


### PR DESCRIPTION
## Summary
- Cherry-pick of #2509 from `release-1.4` to `v1-dev`
- Initializes `registryHostGetter` in `MIAuthProvider` to prevent nil pointer panic

## Original PR
https://github.com/notaryproject/ratify/pull/2509