### PR TITLE
fix: add emptyDir for ORAS local cache to support nonroot image builds

### DIFF
--- a/charts/ratify/templates/deployment.yaml
+++ b/charts/ratify/templates/deployment.yaml
@@ -127,6 +127,8 @@ spec:
               name: client-ca-cert-{{ $cert.secretName }}
               readOnly: true
             {{- end }}
+            - mountPath: /.ratify/local_oras_cache
+              name: ratify-cache
           env:
           {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
@@ -206,6 +208,8 @@ spec:
               - key: {{ $cert.secretKey }}
                 path: {{ $i }}-{{ $cert.secretName }}.crt
         {{- end }}
+        - name: ratify-cache
+          emptyDir: {}
       affinity:
         {{- toYaml .Values.affinity | nindent 8 }}
       tolerations:


### PR DESCRIPTION
## Summary
- Cherry-pick of #2516 from `release-1.4` to `v1-dev`
- Adds emptyDir volume for ORAS local cache to support nonroot image builds

## Original PR
https://github.com/notaryproject/ratify/pull/2516