### PR TITLE
refactor: use dynamic naming for chart RBAC resources and standardize helm release name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ SBOM_TOOL_VERSION ?=v2.2.9
 TRIVY_VERSION ?= 0.71.0
 
 GATEKEEPER_NAMESPACE = gatekeeper-system
-RATIFY_NAME = ratify
+RATIFY_NAME = ratify-gatekeeper-provider
 
 TIMESTAMP_URL = http://timestamp.digicert.com
 

--- a/deployments/ratify-gatekeeper-provider/templates/ratify-manager-role-clusterrole.yaml
+++ b/deployments/ratify-gatekeeper-provider/templates/ratify-manager-role-clusterrole.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: ratify-manager-cluster-role
+  name: {{ include "ratify.fullname" . }}-manager-cluster-role
 rules:
 - apiGroups:
   - externaldata.gatekeeper.sh

--- a/deployments/ratify-gatekeeper-provider/templates/ratify-manager-role-role.yaml
+++ b/deployments/ratify-gatekeeper-provider/templates/ratify-manager-role-role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   creationTimestamp: null
-  name: ratify-manager-role
+  name: {{ include "ratify.fullname" . }}-manager-role
 rules:
 - apiGroups:
   - ""

--- a/deployments/ratify-gatekeeper-provider/templates/ratify-manager-rolebinding-clusterrolebinding.yaml
+++ b/deployments/ratify-gatekeeper-provider/templates/ratify-manager-rolebinding-clusterrolebinding.yaml
@@ -5,13 +5,13 @@ metadata:
   labels:
     heritage: '{{ .Release.Service }}'
     release: '{{ .Release.Name }}'
-  name: ratify-manager-cluster-rolebinding
+  name: {{ include "ratify.fullname" . }}-manager-cluster-rolebinding
 subjects:
 - kind: ServiceAccount
   name: {{ include "ratify.serviceAccountName" . }} 
   namespace: '{{ .Release.Namespace }}'
 roleRef:
   kind: ClusterRole
-  name: ratify-manager-cluster-role
+  name: {{ include "ratify.fullname" . }}-manager-cluster-role
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/deployments/ratify-gatekeeper-provider/templates/ratify-manager-rolebinding-rolebinding.yaml
+++ b/deployments/ratify-gatekeeper-provider/templates/ratify-manager-rolebinding-rolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     heritage: '{{ .Release.Service }}'
     release: '{{ .Release.Name }}'
-  name: ratify-manager-rolebinding
+  name: {{ include "ratify.fullname" . }}-manager-rolebinding
   namespace: {{ .Release.Namespace }}
 subjects:
 - kind: ServiceAccount
@@ -13,6 +13,6 @@ subjects:
   namespace: '{{ .Release.Namespace }}'
 roleRef:
   kind: Role
-  name: ratify-manager-role
+  name: {{ include "ratify.fullname" . }}-manager-role
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/test/bats/tests/config/executor_cosign_akv.yaml
+++ b/test/bats/tests/config/executor_cosign_akv.yaml
@@ -1,7 +1,7 @@
 apiVersion: config.ratify.dev/v2alpha1
 kind: Executor
 metadata:
-  name: ratify-ratify-gatekeeper-provider-executor-1
+  name: ratify-gatekeeper-provider-executor-1
 spec:
   scopes:
     - "registry:5000"

--- a/test/bats/tests/config/executor_cosign_keyless.yaml
+++ b/test/bats/tests/config/executor_cosign_keyless.yaml
@@ -1,7 +1,7 @@
 apiVersion: config.ratify.dev/v2alpha1
 kind: Executor
 metadata:
-  name: ratify-ratify-gatekeeper-provider-executor-1
+  name: ratify-gatekeeper-provider-executor-1
 spec:
   scopes:
     - "wabbitnetworks.azurecr.io"

--- a/test/bats/tests/config/executor_cosign_legacy.yaml
+++ b/test/bats/tests/config/executor_cosign_legacy.yaml
@@ -1,7 +1,7 @@
 apiVersion: config.ratify.dev/v2alpha1
 kind: Executor
 metadata:
-  name: ratify-ratify-gatekeeper-provider-executor-1
+  name: ratify-gatekeeper-provider-executor-1
 spec:
   scopes:
     - "registry:5000"

--- a/test/bats/tests/config/executor_cosign_legacy_keyless.yaml
+++ b/test/bats/tests/config/executor_cosign_legacy_keyless.yaml
@@ -1,7 +1,7 @@
 apiVersion: config.ratify.dev/v2alpha1
 kind: Executor
 metadata:
-  name: ratify-ratify-gatekeeper-provider-executor-1
+  name: ratify-gatekeeper-provider-executor-1
 spec:
   scopes:
     - "wabbitnetworks.azurecr.io"

--- a/test/bats/tests/config/executor_invalid_store.yaml
+++ b/test/bats/tests/config/executor_invalid_store.yaml
@@ -1,7 +1,7 @@
 apiVersion: config.ratify.dev/v2alpha1
 kind: Executor
 metadata:
-  name: ratify-ratify-gatekeeper-provider-executor-1
+  name: ratify-gatekeeper-provider-executor-1
 spec:
   scopes:
     - "registry:5000"

--- a/test/bats/tests/config/executor_k8s_secret_auth.yaml
+++ b/test/bats/tests/config/executor_k8s_secret_auth.yaml
@@ -1,7 +1,7 @@
 apiVersion: config.ratify.dev/v2alpha1
 kind: Executor
 metadata:
-  name: ratify-ratify-gatekeeper-provider-executor-1
+  name: ratify-gatekeeper-provider-executor-1
 spec:
   scopes:
     - "registry:5000"

--- a/test/bats/tests/config/executor_no_notation.yaml
+++ b/test/bats/tests/config/executor_no_notation.yaml
@@ -1,7 +1,7 @@
 apiVersion: config.ratify.dev/v2alpha1
 kind: Executor
 metadata:
-  name: ratify-ratify-gatekeeper-provider-executor-1
+  name: ratify-gatekeeper-provider-executor-1
 spec:
   scopes:
     - "registry:5000"

--- a/test/bats/tests/config/executor_no_verifiers.yaml
+++ b/test/bats/tests/config/executor_no_verifiers.yaml
@@ -1,7 +1,7 @@
 apiVersion: config.ratify.dev/v2alpha1
 kind: Executor
 metadata:
-  name: ratify-ratify-gatekeeper-provider-executor-1
+  name: ratify-gatekeeper-provider-executor-1
 spec:
   scopes:
     - "registry:5000"

--- a/test/bats/tests/config/executor_notation_akv.yaml
+++ b/test/bats/tests/config/executor_notation_akv.yaml
@@ -1,7 +1,7 @@
 apiVersion: config.ratify.dev/v2alpha1
 kind: Executor
 metadata:
-  name: ratify-ratify-gatekeeper-provider-executor-1
+  name: ratify-gatekeeper-provider-executor-1
 spec:
   scopes:
     - "registry:5000"


### PR DESCRIPTION
## Summary
- Replace hardcoded RBAC resource names with `{{ include "ratify.fullname" . }}` in Helm chart templates
- Standardize helm release name to `ratify-gatekeeper-provider` in Makefile and test fixtures
- Provider CR names remain hardcoded as they must match the ConstraintTemplate rego policy

## Resources updated
| Resource | Before | After |
|----------|--------|-------|
| ClusterRole | `ratify-manager-cluster-role` | `{{ fullname }}-manager-cluster-role` |
| ClusterRoleBinding | `ratify-manager-cluster-rolebinding` | `{{ fullname }}-manager-cluster-rolebinding` |
| Role | `ratify-manager-role` | `{{ fullname }}-manager-role` |
| RoleBinding | `ratify-manager-rolebinding` | `{{ fullname }}-manager-rolebinding` |
| Provider (validation) | `ratify-gatekeeper-provider` | `ratify-gatekeeper-provider` (unchanged, must match ConstraintTemplate) |
| Provider (mutation) | `ratify-gatekeeper-mutation-provider` | `ratify-gatekeeper-mutation-provider` (unchanged) |

## Other changes
- Makefile: `RATIFY_NAME = ratify` → `RATIFY_NAME = ratify-gatekeeper-provider`
- Test fixtures: executor names updated from `ratify-ratify-gatekeeper-provider-executor-1` to `ratify-gatekeeper-provider-executor-1`