### PR TITLE
ci: fix workflow_dispatch for e2e tests

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -34,7 +34,7 @@ jobs:
 
   build_test_e2e_full_conditional:
     name: "run e2e on full test matrix with conditions"
-    if: contains(github.event.pull_request.labels.*.name, 'safe to test') || github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/v1'
+    if: contains(github.event.pull_request.labels.*.name, 'safe to test') || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/e2e-k8s.yml
+++ b/.github/workflows/e2e-k8s.yml
@@ -4,6 +4,18 @@ permissions:
   contents: read
 
 on:
+  workflow_dispatch:
+    inputs:
+      k8s_version:
+        description: "Kubernetes version"
+        required: true
+        default: "1.31.2"
+        type: string
+      gatekeeper_version:
+        description: "Gatekeeper version"
+        required: true
+        default: "3.18.0"
+        type: string
   workflow_call:
     inputs:
       k8s_version:


### PR DESCRIPTION
## Summary
- Remove `github.ref == 'refs/heads/v1'` branch restriction from `build-pr` full matrix job so `workflow_dispatch` works on any branch
- Add `workflow_dispatch` trigger to `e2e-k8s.yml` so it can be triggered independently from the Actions page

## Problem
When triggering `build-pr` via `workflow_dispatch`:
- basic matrix is skipped (by design, to run full matrix instead)
- full matrix requires `refs/heads/v1` branch, so it's also skipped
- Result: no e2e tests run at all

## Test plan
- [ ] Trigger `build-pr` via `workflow_dispatch` on a non-v1 branch and verify full matrix runs
- [ ] Trigger `e2e-k8s` directly via `workflow_dispatch` and verify it runs