### PR TITLE
fix: executor template inline cert must use {certs: PEM} format

### DIFF
--- a/deployments/ratify-gatekeeper-provider/templates/executor.yaml
+++ b/deployments/ratify-gatekeeper-provider/templates/executor.yaml
@@ -105,7 +105,8 @@ spec:
         certificates:
           - type: "ca"
             {{- if eq (index .Values.notation.certs 0).provider "inline" }}
-            inline: {{ (index .Values.notation.certs 0).cert | quote }}
+            inline:
+              certs: {{ (index .Values.notation.certs 0).cert | quote }}
             {{- else if eq (index .Values.notation.certs 0).provider "files" }}
             files:
               - "/usr/local/notation/certs"


### PR DESCRIPTION
## Summary
- Fix executor template to render inline notation cert as `inline: {certs: "PEM"}` instead of `inline: "PEM"`

## Problem
The `inlineprovider` expects options in the form `{"certs": "PEM string"}`, but the executor template rendered it as a bare string (`inline: "PEM"`), causing json unmarshal to fail:
```
failed to unmarshal options: json: cannot unmarshal string into Go value of type inlineprovider.inlineOptions
```
This prevented the executor from being reconciled and loaded, resulting in `no valid executor configured` errors at runtime.

## Root Cause

The call chain is:

1. `internal/verifier/notation/register.go:109` — `keyprovider.CreateKeyProvider(key, val)` where `key = "inline"` and `val` is the value after `inline:` in the executor YAML
2. `internal/verifier/keyprovider/inlineprovider/register.go` — marshals `val` to JSON then unmarshals into `inlineOptions`:
   ```go
   type inlineOptions struct {
       Certs string `json:"certs,omitempty"`
       Keys  string `json:"keys,omitempty"`
   }
   ```

With the old template (`inline: "PEM"`), `val` is a Go `string`. `json.Marshal(string)` produces `"PEM"`, and `json.Unmarshal("PEM", &inlineOptions{})` fails because a JSON string cannot be unmarshaled into a struct.

With the fix (`inline: {certs: "PEM"}`), `val` is a `map[string]interface{}{"certs": "PEM"}`. `json.Marshal(map)` produces `{"certs":"PEM"}`, and `json.Unmarshal({"certs":"PEM"}, &inlineOptions{})` succeeds.

## Test plan
- [x] `helm template` renders correct format: `inline: {certs: "..."}`
- [x] Verified with e2e test — executor reconciles successfully after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)