### PR TITLE
fix: strip namespace prefix from artifact in executor scope matching

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -151,7 +151,7 @@ func (s *ScopedExecutor) ValidateArtifact(ctx context.Context, artifact string) 
 	reference := stripNamespacePrefix(artifact)
 	executor, err := s.matchExecutor(reference)
 	if err != nil {
-		return nil, fmt.Errorf("failed to match executor for artifact %q (original: %q): %w", reference, artifact, err)
+		return nil, fmt.Errorf("failed to match executor for artifact %q: %w", reference, err)
 	}
 	opts := ratify.ValidateArtifactOptions{
 		Subject: reference,
@@ -166,7 +166,7 @@ func (s *ScopedExecutor) Resolve(ctx context.Context, artifact string) (ocispec.
 	reference := stripNamespacePrefix(artifact)
 	executor, err := s.matchExecutor(reference)
 	if err != nil {
-		return ocispec.Descriptor{}, fmt.Errorf("failed to match executor for artifact %q (original: %q): %w", reference, artifact, err)
+		return ocispec.Descriptor{}, fmt.Errorf("failed to match executor for artifact %q: %w", reference, err)
 	}
 	return executor.Store.Resolve(ctx, reference)
 }

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -148,6 +148,7 @@ func newExecutor(opts ScopedOptions) (*ratify.Executor, error) {
 // executor based on the artifact's reference. It returns the validation result
 // or an error if no matching executor is found.
 func (s *ScopedExecutor) ValidateArtifact(ctx context.Context, artifact string) (*ratify.ValidationResult, error) {
+	artifact = stripNamespacePrefix(artifact)
 	executor, err := s.matchExecutor(artifact)
 	if err != nil {
 		return nil, fmt.Errorf("failed to match executor for artifact %q: %w", artifact, err)
@@ -162,11 +163,24 @@ func (s *ScopedExecutor) ValidateArtifact(ctx context.Context, artifact string) 
 // request to the appropriate executor based on the artifact's reference.
 // It returns the descriptor or an error if no matching executor is found.
 func (s *ScopedExecutor) Resolve(ctx context.Context, artifact string) (ocispec.Descriptor, error) {
+	artifact = stripNamespacePrefix(artifact)
 	executor, err := s.matchExecutor(artifact)
 	if err != nil {
 		return ocispec.Descriptor{}, fmt.Errorf("failed to match executor for artifact %q: %w", artifact, err)
 	}
 	return executor.Store.Resolve(ctx, artifact)
+}
+
+// stripNamespacePrefix removes a leading [namespace] prefix from an artifact
+// reference. Gatekeeper constraint templates prepend [namespace] to image refs
+// before sending them to ratify via external data.
+func stripNamespacePrefix(artifact string) string {
+	if strings.HasPrefix(artifact, "[") {
+		if idx := strings.Index(artifact, "]"); idx != -1 {
+			return artifact[idx+1:]
+		}
+	}
+	return artifact
 }
 
 // matchExecutor finds the appropriate executor for the given artifact.

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -148,13 +148,13 @@ func newExecutor(opts ScopedOptions) (*ratify.Executor, error) {
 // executor based on the artifact's reference. It returns the validation result
 // or an error if no matching executor is found.
 func (s *ScopedExecutor) ValidateArtifact(ctx context.Context, artifact string) (*ratify.ValidationResult, error) {
-	artifact = stripNamespacePrefix(artifact)
-	executor, err := s.matchExecutor(artifact)
+	reference := stripNamespacePrefix(artifact)
+	executor, err := s.matchExecutor(reference)
 	if err != nil {
-		return nil, fmt.Errorf("failed to match executor for artifact %q: %w", artifact, err)
+		return nil, fmt.Errorf("failed to match executor for artifact %q (original: %q): %w", reference, artifact, err)
 	}
 	opts := ratify.ValidateArtifactOptions{
-		Subject: artifact,
+		Subject: reference,
 	}
 	return executor.ValidateArtifact(ctx, opts)
 }
@@ -163,12 +163,12 @@ func (s *ScopedExecutor) ValidateArtifact(ctx context.Context, artifact string) 
 // request to the appropriate executor based on the artifact's reference.
 // It returns the descriptor or an error if no matching executor is found.
 func (s *ScopedExecutor) Resolve(ctx context.Context, artifact string) (ocispec.Descriptor, error) {
-	artifact = stripNamespacePrefix(artifact)
-	executor, err := s.matchExecutor(artifact)
+	reference := stripNamespacePrefix(artifact)
+	executor, err := s.matchExecutor(reference)
 	if err != nil {
-		return ocispec.Descriptor{}, fmt.Errorf("failed to match executor for artifact %q: %w", artifact, err)
+		return ocispec.Descriptor{}, fmt.Errorf("failed to match executor for artifact %q (original: %q): %w", reference, artifact, err)
 	}
-	return executor.Store.Resolve(ctx, artifact)
+	return executor.Store.Resolve(ctx, reference)
 }
 
 // stripNamespacePrefix removes a leading [namespace] prefix from an artifact

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -373,6 +373,12 @@ func TestMatchExecutor(t *testing.T) {
 			expectedError:    false,
 		},
 		{
+			name:             "Match registry executor with namespace prefix",
+			artifact:         "[default]registry.example.com/foo:v1",
+			expectedExecutor: nil,
+			expectedError:    true,
+		},
+		{
 			name:             "No match",
 			artifact:         "unknown.com/foo:v1",
 			expectedExecutor: nil,
@@ -388,6 +394,49 @@ func TestMatchExecutor(t *testing.T) {
 			}
 			if executor != test.expectedExecutor {
 				t.Errorf("expected executor: %v, got: %v", test.expectedExecutor, executor)
+			}
+		})
+	}
+}
+
+func TestStripNamespacePrefix(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "No prefix",
+			input:    "registry:5000/notation@sha256:abc123",
+			expected: "registry:5000/notation@sha256:abc123",
+		},
+		{
+			name:     "Default namespace prefix",
+			input:    "[default]registry:5000/notation@sha256:abc123",
+			expected: "registry:5000/notation@sha256:abc123",
+		},
+		{
+			name:     "Custom namespace prefix",
+			input:    "[my-namespace]registry.example.com/foo:v1",
+			expected: "registry.example.com/foo:v1",
+		},
+		{
+			name:     "Empty namespace prefix",
+			input:    "[]registry:5000/foo:v1",
+			expected: "registry:5000/foo:v1",
+		},
+		{
+			name:     "No closing bracket",
+			input:    "[defaultregistry:5000/foo:v1",
+			expected: "[defaultregistry:5000/foo:v1",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := stripNamespacePrefix(test.input)
+			if result != test.expected {
+				t.Errorf("expected %q, got %q", test.expected, result)
 			}
 		})
 	}

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -430,6 +430,11 @@ func TestStripNamespacePrefix(t *testing.T) {
 			input:    "[defaultregistry:5000/foo:v1",
 			expected: "[defaultregistry:5000/foo:v1",
 		},
+		{
+			name:     "Namespace prefix with IPv6 registry",
+			input:    "[default][2001:db8::1]:5000/repo:tag",
+			expected: "[2001:db8::1]:5000/repo:tag",
+		},
 	}
 
 	for _, test := range tests {
@@ -456,6 +461,11 @@ func TestValidateArtifact(t *testing.T) {
 	if _, err := scopedExecutor.ValidateArtifact(context.Background(), "test.example.com/foo:v1"); err == nil {
 		t.Error("expected error for artifact with wildcard scope, got nil")
 	}
+
+	// Verify namespace prefix is stripped before scope matching
+	if _, err := scopedExecutor.ValidateArtifact(context.Background(), "[default]unknown.com/foo:v1"); err == nil {
+		t.Error("expected error for prefixed unknown artifact, got nil")
+	}
 }
 
 func TestResolve(t *testing.T) {
@@ -473,6 +483,15 @@ func TestResolve(t *testing.T) {
 
 	if _, err := scopedExecutor.Resolve(context.Background(), "test.example.com/foo:v1"); err != nil {
 		t.Error("expected no error for valid artifact with wildcard scope, got:", err)
+	}
+
+	// Verify namespace prefix is stripped before scope matching
+	if _, err := scopedExecutor.Resolve(context.Background(), "[default]test.example.com/foo:v1"); err != nil {
+		t.Error("expected no error for prefixed artifact with wildcard scope, got:", err)
+	}
+
+	if _, err := scopedExecutor.Resolve(context.Background(), "[default]unknown.com/foo:v1"); err == nil {
+		t.Error("expected error for prefixed unknown artifact, got nil")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Strip `[namespace]` prefix from artifact reference before executor scope matching

## Problem
Gatekeeper constraint templates encode namespace information into the image reference as a prefix: `[default]registry:5000/notation:signed`. The executor's `matchExecutor` uses scope patterns (e.g., `registry:5000`) to find matching executors, but the `[default]` prefix causes the match to fail, resulting in `no valid executor configured`.

## Root Cause
The constraint template rego builds image keys with namespace prefix for multi-tenancy support:
```rego
images := [img | img = concat("", ["[", input.review.object.metadata.namespace, "]", input.review.object.spec.containers[_].image])]
```

The v2 executor's `matchExecutor` did not strip this prefix before scope matching. The v1 httpserver handled this in a different code path.

## Fix
Add `stripNamespacePrefix` to remove the `[namespace]` prefix from the artifact reference in both `Verify` and paths before scope matching. If no prefix is present, the artifact is returned unchanged.

## Test plan
- [x] Unit tests for `stripNamespacePrefix` covering: no prefix, default namespace, custom namespace, empty namespace, no closing bracket
- [x] Verified with e2e test — executor scope matching works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)