### PR TITLE
ci: Update e2e workflow log collection

### DIFF
--- a/.github/workflows/e2e-k8s.yml
+++ b/.github/workflows/e2e-k8s.yml
@@ -64,8 +64,8 @@ jobs:
       - name: Save logs
         if: ${{ always() }}
         run: |
-          kubectl logs -n gatekeeper-system -l app=ratify --tail=-1 > logs-ratify-preinstall-${{ inputs.k8s_version }}-${{ inputs.gatekeeper_version }}-config-policy.json
-          kubectl logs -n gatekeeper-system -l app.kubernetes.io/name=ratify --tail=-1 > logs-ratify-${{ inputs.k8s_version }}-${{ inputs.gatekeeper_version }}-config-policy.json
+          kubectl logs -n gatekeeper-system -l app.kubernetes.io/name=ratify-gatekeeper-provider --tail=-1 > logs-ratify-${{ inputs.k8s_version }}-${{ inputs.gatekeeper_version }}-config-policy.json
+          kubectl get executors.config.ratify.dev -A -o yaml > logs-executor-${{ inputs.k8s_version }}-${{ inputs.gatekeeper_version }}.json 2>&1 || true
       - name: Run e2e with Rego policy
         run: |
           make deploy-rego-policy

--- a/.github/workflows/e2e-k8s.yml
+++ b/.github/workflows/e2e-k8s.yml
@@ -64,8 +64,8 @@ jobs:
       - name: Save logs
         if: ${{ always() }}
         run: |
-          kubectl logs -n gatekeeper-system -l app.kubernetes.io/name=ratify-gatekeeper-provider --tail=-1 > logs-ratify-${{ inputs.k8s_version }}-${{ inputs.gatekeeper_version }}-config-policy.json
-          kubectl get executors.config.ratify.dev -A -o yaml > logs-executor-${{ inputs.k8s_version }}-${{ inputs.gatekeeper_version }}.json 2>&1 || true
+          kubectl logs -n gatekeeper-system -l app.kubernetes.io/name=ratify-gatekeeper-provider --tail=-1 > logs-ratify-provider-${{ inputs.k8s_version }}-${{ inputs.gatekeeper_version }}-config-policy.json 2>&1 || true
+          kubectl get executors.config.ratify.dev -A -o yaml > logs-executor-${{ inputs.k8s_version }}-${{ inputs.gatekeeper_version }}.yaml 2>&1 || true
       - name: Run e2e with Rego policy
         run: |
           make deploy-rego-policy


### PR DESCRIPTION
#### What this PR does / why we need it
Updates the e2e Kubernetes workflow log collection to gather logs from the ratify-gatekeeper-provider pods and capture Executor CRD state for debugging.

#### Which issue(s) this PR fixes
None

#### Special notes for your reviewer
This contains the .github/workflows/e2e-k8s.yml change from https://github.com/fseldow/ratify/pull/2/files#diff-0148a13b3bb09acc3a39dcb9bd98f4c723546f07b69fcb4a111c64ddd7260d88.