### PR TITLE
test: improve coverage for API and utility packages

### DIFF
--- a/api/v2alpha1/deepcopy_test.go
+++ b/api/v2alpha1/deepcopy_test.go
@@ -1,0 +1,200 @@
+/*
+Copyright The Ratify Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2alpha1
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestExecutorDeepCopy(t *testing.T) {
+	executor := &Executor{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Executor",
+			APIVersion: GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-executor",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				"app": "ratify",
+			},
+		},
+		Spec: ExecutorSpec{
+			Scopes: []string{"namespace-a", "namespace-b"},
+			Verifiers: []*VerifierOptions{
+				{
+					Name:       "notation",
+					Type:       "notation",
+					Parameters: runtime.RawExtension{Raw: []byte(`{"trustPolicyDoc":"policy"}`)},
+				},
+				nil,
+			},
+			Stores: []*StoreOptions{
+				{
+					Type:       "oras",
+					Parameters: runtime.RawExtension{Raw: []byte(`{"cacheEnabled":true}`)},
+				},
+				nil,
+			},
+			PolicyEnforcer: &PolicyEnforcerOptions{
+				Type:       "threshold",
+				Parameters: runtime.RawExtension{Raw: []byte(`{"threshold":1}`)},
+			},
+			Concurrency: 4,
+		},
+		Status: ExecutorStatus{
+			Succeeded:  true,
+			Error:      "full error",
+			BriefError: "brief error",
+		},
+	}
+
+	copied := executor.DeepCopy()
+	if copied == executor {
+		t.Fatal("expected a distinct Executor copy")
+	}
+	if copied.Name != executor.Name || copied.Namespace != executor.Namespace {
+		t.Fatalf("expected metadata to be copied, got %s/%s", copied.Namespace, copied.Name)
+	}
+	if copied.Spec.Verifiers[0] == executor.Spec.Verifiers[0] {
+		t.Fatal("expected verifier options to be deep copied")
+	}
+	if copied.Spec.Stores[0] == executor.Spec.Stores[0] {
+		t.Fatal("expected store options to be deep copied")
+	}
+	if copied.Spec.PolicyEnforcer == executor.Spec.PolicyEnforcer {
+		t.Fatal("expected policy enforcer options to be deep copied")
+	}
+	if copied.Spec.Verifiers[1] != nil {
+		t.Fatal("expected nil verifier entry to remain nil")
+	}
+	if copied.Spec.Stores[1] != nil {
+		t.Fatal("expected nil store entry to remain nil")
+	}
+
+	executor.Labels["app"] = "mutated"
+	executor.Spec.Scopes[0] = "mutated"
+	executor.Spec.Verifiers[0].Parameters.Raw[0] = '['
+	executor.Spec.Stores[0].Parameters.Raw[0] = '['
+	executor.Spec.PolicyEnforcer.Parameters.Raw[0] = '['
+
+	if copied.Labels["app"] != "ratify" {
+		t.Errorf("expected labels to be isolated, got %q", copied.Labels["app"])
+	}
+	if copied.Spec.Scopes[0] != "namespace-a" {
+		t.Errorf("expected scopes to be isolated, got %q", copied.Spec.Scopes[0])
+	}
+	if string(copied.Spec.Verifiers[0].Parameters.Raw) != `{"trustPolicyDoc":"policy"}` {
+		t.Errorf("expected verifier parameters to be isolated, got %s", copied.Spec.Verifiers[0].Parameters.Raw)
+	}
+	if string(copied.Spec.Stores[0].Parameters.Raw) != `{"cacheEnabled":true}` {
+		t.Errorf("expected store parameters to be isolated, got %s", copied.Spec.Stores[0].Parameters.Raw)
+	}
+	if string(copied.Spec.PolicyEnforcer.Parameters.Raw) != `{"threshold":1}` {
+		t.Errorf("expected policy enforcer parameters to be isolated, got %s", copied.Spec.PolicyEnforcer.Parameters.Raw)
+	}
+
+	if obj := executor.DeepCopyObject(); obj == nil {
+		t.Fatal("expected non-nil runtime object copy")
+	}
+}
+
+func TestExecutorListDeepCopy(t *testing.T) {
+	list := &ExecutorList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ExecutorList",
+			APIVersion: GroupVersion.String(),
+		},
+		ListMeta: metav1.ListMeta{
+			ResourceVersion: "123",
+		},
+		Items: []Executor{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "executor-a"},
+				Spec: ExecutorSpec{
+					Scopes: []string{"namespace-a"},
+					Verifiers: []*VerifierOptions{
+						{Name: "notation", Type: "notation"},
+					},
+				},
+			},
+		},
+	}
+
+	copied := list.DeepCopy()
+	if copied == list {
+		t.Fatal("expected a distinct ExecutorList copy")
+	}
+	if copied.Items[0].Spec.Verifiers[0] == list.Items[0].Spec.Verifiers[0] {
+		t.Fatal("expected nested Executor items to be deep copied")
+	}
+
+	list.Items[0].Spec.Verifiers[0].Name = "mutated"
+	if copied.Items[0].Spec.Verifiers[0].Name != "notation" {
+		t.Errorf("expected copied list item to be isolated, got %q", copied.Items[0].Spec.Verifiers[0].Name)
+	}
+
+	if obj := list.DeepCopyObject(); obj == nil {
+		t.Fatal("expected non-nil runtime object copy")
+	}
+}
+
+func TestDeepCopyNilReceivers(t *testing.T) {
+	var executor *Executor
+	if executor.DeepCopy() != nil {
+		t.Fatal("expected nil Executor deepcopy")
+	}
+	if executor.DeepCopyObject() != nil {
+		t.Fatal("expected nil Executor runtime object deepcopy")
+	}
+
+	var executorList *ExecutorList
+	if executorList.DeepCopy() != nil {
+		t.Fatal("expected nil ExecutorList deepcopy")
+	}
+	if executorList.DeepCopyObject() != nil {
+		t.Fatal("expected nil ExecutorList runtime object deepcopy")
+	}
+
+	var spec *ExecutorSpec
+	if spec.DeepCopy() != nil {
+		t.Fatal("expected nil ExecutorSpec deepcopy")
+	}
+
+	var status *ExecutorStatus
+	if status.DeepCopy() != nil {
+		t.Fatal("expected nil ExecutorStatus deepcopy")
+	}
+
+	var policyEnforcer *PolicyEnforcerOptions
+	if policyEnforcer.DeepCopy() != nil {
+		t.Fatal("expected nil PolicyEnforcerOptions deepcopy")
+	}
+
+	var store *StoreOptions
+	if store.DeepCopy() != nil {
+		t.Fatal("expected nil StoreOptions deepcopy")
+	}
+
+	var verifier *VerifierOptions
+	if verifier.DeepCopy() != nil {
+		t.Fatal("expected nil VerifierOptions deepcopy")
+	}
+}

--- a/pkg/common/plugin/download_additional_test.go
+++ b/pkg/common/plugin/download_additional_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugin
+
+import "testing"
+
+func TestParsePluginSourceMarshalError(t *testing.T) {
+	_, err := ParsePluginSource(func() {})
+	if err == nil {
+		t.Fatal("expected marshal error")
+	}
+}
+
+func TestDownloadPluginInvalidArtifact(t *testing.T) {
+	err := DownloadPlugin(PluginSource{Artifact: "://bad-reference"}, t.TempDir()+"/plugin")
+	if err == nil {
+		t.Fatal("expected invalid artifact error")
+	}
+}

--- a/pkg/common/plugin/exec_additional_test.go
+++ b/pkg/common/plugin/exec_additional_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugin
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestExecutePluginSuccess(t *testing.T) {
+	pluginPath := writePluginScript(t, `#!/bin/sh
+echo "info: starting" >&2
+echo '{"ok":true}'
+echo "warn: done" >&2
+`)
+
+	executor := &DefaultExecutor{}
+	output, err := executor.ExecutePlugin(context.Background(), pluginPath, []string{"arg"}, []byte("stdin"), []string{"RATIFY_TEST=value"})
+	if err != nil {
+		t.Fatalf("expected plugin execution to succeed: %v", err)
+	}
+	if string(output) != `{"ok":true}` {
+		t.Fatalf("expected JSON output, got %s", output)
+	}
+}
+
+func TestExecutePluginError(t *testing.T) {
+	pluginPath := writePluginScript(t, `#!/bin/sh
+echo "stdout failure"
+echo "stderr failure" >&2
+exit 7
+`)
+
+	executor := &DefaultExecutor{}
+	_, err := executor.ExecutePlugin(context.Background(), pluginPath, nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected plugin execution error")
+	}
+	if !strings.Contains(err.Error(), "stderr failure") {
+		t.Fatalf("expected stderr in error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "stdout failure") {
+		t.Fatalf("expected stdout in error, got %v", err)
+	}
+}
+
+func TestDefaultExecutorFindInPaths(t *testing.T) {
+	pluginPath := writePluginScript(t, "#!/bin/sh\n")
+	dir, name := splitPluginPath(t, pluginPath)
+
+	executor := &DefaultExecutor{}
+	got, err := executor.FindInPaths(name, []string{dir})
+	if err != nil {
+		t.Fatalf("expected plugin to be found: %v", err)
+	}
+	if got != pluginPath {
+		t.Fatalf("expected %q, got %q", pluginPath, got)
+	}
+}
+
+func TestParsePluginOutputAdditional(t *testing.T) {
+	stdout := bytes.NewBufferString("plain stdout\n{\"status\":\"ok\"}\n")
+	stderr := bytes.NewBufferString("warn: warning message\nnot json {broken\n")
+
+	output, messages := parsePluginOutput(stdout, stderr)
+	if string(output) != `{"status":"ok"}` {
+		t.Fatalf("expected parsed JSON output, got %s", output)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("expected two plugin messages, got %d", len(messages))
+	}
+}

--- a/pkg/common/plugin/testhelpers_test.go
+++ b/pkg/common/plugin/testhelpers_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writePluginScript(t *testing.T, contents string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "test-plugin")
+	if err := os.WriteFile(path, []byte(contents), 0700); err != nil {
+		t.Fatalf("failed to write plugin script: %v", err)
+	}
+	return path
+}
+
+func splitPluginPath(t *testing.T, path string) (string, string) {
+	t.Helper()
+
+	dir, name := filepath.Split(path)
+	return dir, name
+}

--- a/pkg/homedir/homedir_unix_test.go
+++ b/pkg/homedir/homedir_unix_test.go
@@ -1,0 +1,49 @@
+//go:build !windows
+// +build !windows
+
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package homedir
+
+import "testing"
+
+func TestKey(t *testing.T) {
+	if got := Key(); got != "HOME" {
+		t.Fatalf("expected HOME, got %q", got)
+	}
+}
+
+func TestGet(t *testing.T) {
+	t.Setenv(Key(), "/tmp/ratify-home")
+
+	if got := Get(); got != "/tmp/ratify-home" {
+		t.Fatalf("expected /tmp/ratify-home, got %q", got)
+	}
+}
+
+func TestGetFallbackToCurrentUser(t *testing.T) {
+	t.Setenv(Key(), "")
+
+	if got := Get(); got == "" {
+		t.Fatal("expected current user home directory fallback")
+	}
+}
+
+func TestGetShortcutString(t *testing.T) {
+	if got := GetShortcutString(); got != "~" {
+		t.Fatalf("expected ~, got %q", got)
+	}
+}


### PR DESCRIPTION
## What
- Add unit tests for v2alpha1 deepcopy behavior, including runtime.Object copies and nil receivers.
- Add unit tests for plugin execution/parsing helpers and invalid plugin download input.
- Add unit tests for Unix homedir helpers.

## Why
Contributes to #2369 by improving package coverage and raising local aggregate coverage above the 80% target without changing production behavior.

## Validation
- `go test ./api/v2alpha1 ./pkg/homedir ./pkg/common/plugin -cover`
- `go test $(go list ./... | grep -Ev '/internal/controller$|/internal/store/credentialprovider/azure$|/internal/verifier/keyprovider/filesystemprovider$') -coverprofile=/tmp/ratify-cover-pr2.out -covermode=atomic` -> total coverage 81.2%

Note: full `make test` was previously attempted locally, but existing environment-sensitive packages failed outside this change: controller envtest binding, Azure credential provider timeout, and filesystemprovider certificate-count assertion.