### PR TITLE
feat: add CRL revocation checks to notation verifier

### DIFF
--- a/config/samples/config_v2alpha1_executor.yaml
+++ b/config/samples/config_v2alpha1_executor.yaml
@@ -22,6 +22,9 @@ spec:
   verifiers:
     - name: notation-1
       parameters:
+        crl:
+          cache:
+            enabled: true
         certificates:
           - type: ca
             inline: |

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,6 @@ require (
 	github.com/notaryproject/notation-go v1.3.2
 	github.com/notaryproject/ratify-go v0.0.0-20250912144645-8f7f89aff329
 	github.com/notaryproject/ratify-verifier-go/cosign v0.0.0-20250912090755-582a09910433
-	github.com/notaryproject/ratify-verifier-go/notation v0.0.0-20250523045711-b622738d577a
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.37.0
 	github.com/open-policy-agent/cert-controller v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -485,8 +485,6 @@ github.com/notaryproject/ratify-go v0.0.0-20250912144645-8f7f89aff329 h1:QPU718m
 github.com/notaryproject/ratify-go v0.0.0-20250912144645-8f7f89aff329/go.mod h1:skeFG5In355I3GUZj25V5glopSbWDcbY8u/fhwgX+E0=
 github.com/notaryproject/ratify-verifier-go/cosign v0.0.0-20250912090755-582a09910433 h1:BSt96EvpwQo5ca4SRIbeUSfO5+zOEuyXraVpQOdFEGg=
 github.com/notaryproject/ratify-verifier-go/cosign v0.0.0-20250912090755-582a09910433/go.mod h1:4+5h2tJp96UF2jNqaK6SV1ne5+kweyREtaRrN2oXrvM=
-github.com/notaryproject/ratify-verifier-go/notation v0.0.0-20250523045711-b622738d577a h1:Q4B+c5a2hSk93D6d1qteXhMAZnHaWxfJ5A6gefDRF94=
-github.com/notaryproject/ratify-verifier-go/notation v0.0.0-20250523045711-b622738d577a/go.mod h1:mXQTrTrQvOov3awSbT0jEdpf76l8SSfYPyGKDQdq5KY=
 github.com/notaryproject/tspclient-go v1.0.0 h1:AwQ4x0gX8IHnyiZB1tggpn5NFqHpTEm1SDX8YNv4Dg4=
 github.com/notaryproject/tspclient-go v1.0.0/go.mod h1:LGyA/6Kwd2FlM0uk8Vc5il3j0CddbWSHBj/4kxQDbjs=
 github.com/oklog/ulid/v2 v2.1.1 h1:suPZ4ARWLOJLegGFiZZ1dFAkqzhMjL3J1TzI+5wHz8s=

--- a/internal/verifier/notation/register.go
+++ b/internal/verifier/notation/register.go
@@ -22,7 +22,6 @@ import (
 	"github.com/notaryproject/notation-go/verifier/trustpolicy"
 	"github.com/notaryproject/notation-go/verifier/truststore"
 	"github.com/notaryproject/ratify-go"
-	"github.com/notaryproject/ratify-verifier-go/notation"
 	"github.com/notaryproject/ratify/v2/internal/verifier"
 	"github.com/notaryproject/ratify/v2/internal/verifier/keyprovider"
 )
@@ -53,6 +52,18 @@ type options struct {
 	// verifier. Certificates would be loaded into trust store for Notation
 	// verifier to access. Required.
 	Certificates []trustStoreOptions `json:"certificates"`
+
+	// CRL configures certificate revocation list checks. Revocation checks are
+	// enabled by default. Cache is optional and disabled unless configured.
+	CRL crlOptions `json:"crl,omitempty"`
+}
+
+type crlOptions struct {
+	Cache crlCacheOptions `json:"cache,omitempty"`
+}
+
+type crlCacheOptions struct {
+	Enabled bool `json:"enabled,omitempty"`
 }
 
 func init() {
@@ -72,13 +83,14 @@ func init() {
 			return nil, fmt.Errorf("failed to initialize trust store: %w", err)
 		}
 
-		notationOpts := &notation.VerifierOptions{
+		notationOpts := &notationVerifierOptions{
 			Name:           opts.Name,
 			TrustPolicyDoc: initTrustPolicyDocument(params.Scopes, params.TrustedIdentities, types),
 			TrustStore:     trustStore,
+			CRL:            params.CRL,
 		}
 
-		return notation.NewVerifier(notationOpts)
+		return newNotationVerifier(notationOpts)
 	})
 }
 

--- a/internal/verifier/notation/register_test.go
+++ b/internal/verifier/notation/register_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/notaryproject/notation-go/dir"
 	"github.com/notaryproject/notation-go/verifier/truststore"
 	"github.com/notaryproject/ratify/v2/internal/verifier"
 	"github.com/notaryproject/ratify/v2/internal/verifier/keyprovider"
@@ -65,6 +66,12 @@ func createMockKeyProvider(options any) (keyprovider.KeyProvider, error) {
 }
 
 func TestNewVerifier(t *testing.T) {
+	oldCacheDir := dir.UserCacheDir
+	dir.UserCacheDir = t.TempDir()
+	t.Cleanup(func() {
+		dir.UserCacheDir = oldCacheDir
+	})
+
 	// Register the mock key provider
 	keyprovider.RegisterKeyProvider(mockKeyProviderName, createMockKeyProvider)
 
@@ -175,6 +182,27 @@ func TestNewVerifier(t *testing.T) {
 				Type: verifierTypeNotation,
 				Name: testName,
 				Parameters: options{
+					Certificates: []trustStoreOptions{
+						{
+							"type":              "ca",
+							mockKeyProviderName: nil,
+						},
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "Valid notation options with CRL cache enabled",
+			opts: verifier.NewOptions{
+				Type: verifierTypeNotation,
+				Name: testName,
+				Parameters: options{
+					CRL: crlOptions{
+						Cache: crlCacheOptions{
+							Enabled: true,
+						},
+					},
 					Certificates: []trustStoreOptions{
 						{
 							"type":              "ca",

--- a/internal/verifier/notation/revocation.go
+++ b/internal/verifier/notation/revocation.go
@@ -1,0 +1,45 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package notation
+
+import (
+	"net/http"
+
+	corecrl "github.com/notaryproject/notation-core-go/revocation/crl"
+	"github.com/notaryproject/notation-go/dir"
+	notationcrl "github.com/notaryproject/notation-go/verifier/crl"
+)
+
+func createCRLFetcher(cacheEnabled bool) (corecrl.Fetcher, error) {
+	fetcher, err := corecrl.NewHTTPFetcher(&http.Client{})
+	if err != nil {
+		return nil, err
+	}
+	if !cacheEnabled {
+		return fetcher, nil
+	}
+
+	cacheRoot, err := dir.CacheFS().SysPath(dir.PathCRLCache)
+	if err != nil {
+		return nil, err
+	}
+	cache, err := notationcrl.NewFileCache(cacheRoot)
+	if err != nil {
+		return nil, err
+	}
+	fetcher.Cache = cache
+	return fetcher, nil
+}

--- a/internal/verifier/notation/revocation_test.go
+++ b/internal/verifier/notation/revocation_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package notation
+
+import (
+	"context"
+	"crypto/x509"
+	"testing"
+
+	corecrl "github.com/notaryproject/notation-core-go/revocation/crl"
+	"github.com/notaryproject/notation-go/dir"
+	"github.com/notaryproject/notation-go/verifier/trustpolicy"
+	"github.com/notaryproject/notation-go/verifier/truststore"
+	"github.com/notaryproject/ratify-go"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+type mockTrustStore struct{}
+
+func (m *mockTrustStore) GetCertificates(context.Context, truststore.Type, string) ([]*x509.Certificate, error) {
+	return nil, nil
+}
+
+func TestCreateCRLFetcher(t *testing.T) {
+	t.Run("without cache", func(t *testing.T) {
+		fetcher, err := createCRLFetcher(false)
+		if err != nil {
+			t.Fatalf("expected CRL fetcher: %v", err)
+		}
+		httpFetcher, ok := fetcher.(*corecrl.HTTPFetcher)
+		if !ok {
+			t.Fatalf("expected HTTP fetcher, got %T", fetcher)
+		}
+		if httpFetcher.Cache != nil {
+			t.Fatal("expected CRL cache to be disabled")
+		}
+	})
+
+	t.Run("with cache", func(t *testing.T) {
+		oldCacheDir := dir.UserCacheDir
+		dir.UserCacheDir = t.TempDir()
+		t.Cleanup(func() {
+			dir.UserCacheDir = oldCacheDir
+		})
+
+		fetcher, err := createCRLFetcher(true)
+		if err != nil {
+			t.Fatalf("expected CRL fetcher with cache: %v", err)
+		}
+		httpFetcher, ok := fetcher.(*corecrl.HTTPFetcher)
+		if !ok {
+			t.Fatalf("expected HTTP fetcher, got %T", fetcher)
+		}
+		if httpFetcher.Cache == nil {
+			t.Fatal("expected CRL cache to be enabled")
+		}
+	})
+}
+
+func TestNewNotationVerifier(t *testing.T) {
+	verifier, err := newNotationVerifier(&notationVerifierOptions{
+		Name:           testName,
+		TrustPolicyDoc: testTrustPolicyDocument(),
+		TrustStore:     &mockTrustStore{},
+		CRL: crlOptions{
+			Cache: crlCacheOptions{Enabled: false},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected notation verifier with CRL validators: %v", err)
+	}
+	if _, ok := interface{}(verifier).(ratify.Verifier); !ok {
+		t.Fatal("expected verifier to implement ratify.Verifier")
+	}
+	if verifier.Name() != testName {
+		t.Fatalf("expected verifier name %q, got %q", testName, verifier.Name())
+	}
+	if verifier.Type() != verifierTypeNotation {
+		t.Fatalf("expected verifier type %q, got %q", verifierTypeNotation, verifier.Type())
+	}
+	if !verifier.Verifiable(ocispec.Descriptor{
+		ArtifactType: "application/vnd.cncf.notary.signature",
+		MediaType:    ocispec.MediaTypeImageManifest,
+	}) {
+		t.Fatal("expected notation signature artifact to be verifiable")
+	}
+	if verifier.Verifiable(ocispec.Descriptor{
+		ArtifactType: "application/example",
+		MediaType:    ocispec.MediaTypeImageManifest,
+	}) {
+		t.Fatal("expected non-notation artifact to be unverifiable")
+	}
+}
+
+func testTrustPolicyDocument() *trustpolicy.Document {
+	return &trustpolicy.Document{
+		Version: "1.0",
+		TrustPolicies: []trustpolicy.TrustPolicy{
+			{
+				Name:           "default",
+				RegistryScopes: []string{"*"},
+				SignatureVerification: trustpolicy.SignatureVerification{
+					VerificationLevel: "strict",
+				},
+				TrustStores:       []string{"ca:ratify"},
+				TrustedIdentities: []string{"*"},
+			},
+		},
+	}
+}

--- a/internal/verifier/notation/verifier.go
+++ b/internal/verifier/notation/verifier.go
@@ -1,0 +1,148 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package notation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/notaryproject/notation-core-go/revocation"
+	"github.com/notaryproject/notation-core-go/revocation/purpose"
+	notationgo "github.com/notaryproject/notation-go"
+	notationregistry "github.com/notaryproject/notation-go/registry"
+	notationverifier "github.com/notaryproject/notation-go/verifier"
+	"github.com/notaryproject/notation-go/verifier/trustpolicy"
+	"github.com/notaryproject/notation-go/verifier/truststore"
+	"github.com/notaryproject/ratify-go"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/sirupsen/logrus"
+)
+
+type notationVerifierOptions struct {
+	Name           string
+	TrustPolicyDoc *trustpolicy.Document
+	TrustStore     truststore.X509TrustStore
+	CRL            crlOptions
+}
+
+type notationVerifier struct {
+	name     string
+	verifier notationgo.Verifier
+}
+
+func newNotationVerifier(opts *notationVerifierOptions) (*notationVerifier, error) {
+	crlFetcher, err := createCRLFetcher(opts.CRL.Cache.Enabled)
+	if err != nil {
+		logrus.Warnf("failed to create CRL fetcher for notation verifier %s: %v", opts.Name, err)
+	}
+
+	codeSigningValidator, err := revocation.NewWithOptions(revocation.Options{
+		CRLFetcher:       crlFetcher,
+		CertChainPurpose: purpose.CodeSigning,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create code signing revocation validator: %w", err)
+	}
+	timestampingValidator, err := revocation.NewWithOptions(revocation.Options{
+		CRLFetcher:       crlFetcher,
+		CertChainPurpose: purpose.Timestamping,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create timestamping revocation validator: %w", err)
+	}
+
+	v, err := notationverifier.NewWithOptions(
+		opts.TrustPolicyDoc,
+		opts.TrustStore,
+		nil,
+		notationverifier.VerifierOptions{
+			RevocationCodeSigningValidator:  codeSigningValidator,
+			RevocationTimestampingValidator: timestampingValidator,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create notation verifier: %w", err)
+	}
+
+	return &notationVerifier{
+		name:     opts.Name,
+		verifier: v,
+	}, nil
+}
+
+func (v *notationVerifier) Name() string {
+	return v.name
+}
+
+func (v *notationVerifier) Type() string {
+	return verifierTypeNotation
+}
+
+func (v *notationVerifier) Verifiable(artifact ocispec.Descriptor) bool {
+	return artifact.ArtifactType == notationregistry.ArtifactTypeNotation && artifact.MediaType == ocispec.MediaTypeImageManifest
+}
+
+func (v *notationVerifier) Verify(ctx context.Context, opts *ratify.VerifyOptions) (*ratify.VerificationResult, error) {
+	signatureDesc, err := v.getSignatureBlobDesc(ctx, opts.Store, opts.Repository, opts.ArtifactDescriptor)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get signature blob descriptor: %w", err)
+	}
+
+	signatureBlob, err := opts.Store.FetchBlob(ctx, opts.Repository, signatureDesc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch signature blob: %w", err)
+	}
+
+	result := &ratify.VerificationResult{
+		Verifier: v,
+	}
+	verifyOpts := notationgo.VerifierVerifyOptions{
+		SignatureMediaType: signatureDesc.MediaType,
+		ArtifactReference:  opts.Repository + "@" + opts.SubjectDescriptor.Digest.String(),
+	}
+	outcome, err := v.verifier.Verify(ctx, opts.SubjectDescriptor, signatureBlob, verifyOpts)
+	if err != nil {
+		result.Err = err
+		return result, nil
+	}
+
+	cert := outcome.EnvelopeContent.SignerInfo.CertificateChain[0]
+	result.Detail = map[string]string{
+		"Issuer": cert.Issuer.String(),
+		"SN":     cert.Subject.String(),
+	}
+	result.Description = "Notation signature verification succeeded"
+	return result, nil
+}
+
+func (v *notationVerifier) getSignatureBlobDesc(ctx context.Context, store ratify.Store, repo string, artifactDesc ocispec.Descriptor) (ocispec.Descriptor, error) {
+	manifestBytes, err := store.FetchManifest(ctx, repo, artifactDesc)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("failed to fetch manifest for artifact: %w", err)
+	}
+
+	var manifest ocispec.Manifest
+	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("failed to unmarshal manifest: %w", err)
+	}
+
+	if len(manifest.Layers) != 1 {
+		return ocispec.Descriptor{}, fmt.Errorf("notation signature manifest requires exactly one signature envelope blob, got %d", len(manifest.Layers))
+	}
+
+	return manifest.Layers[0], nil
+}


### PR DESCRIPTION
## What
- Create the v2 Notation verifier with notation-go revocation validators for code signing and timestamping certificate chains.
- Add CRL HTTP fetching with optional file cache via notation verifier parameters: `crl.cache.enabled`.
- Update the v2 Executor sample to show CRL cache configuration.
- Remove the no-longer-used `ratify-verifier-go/notation` dependency.

## Why
Ratify v1 wires CRL revocation validation into the Notation verifier, but v2 did not. This brings v2 behavior closer to v1 by enabling certificate revocation checks for Notation signature verification.

## Validation
- `go test ./internal/verifier/notation ./internal/verifier`
- `go test ./internal/verifier ./internal/verifier/cosign ./internal/verifier/keyprovider ./internal/verifier/keyprovider/azurekeyvault ./internal/verifier/keyprovider/inlineprovider ./internal/verifier/notation`

Note: `go test ./internal/verifier/...` was also attempted locally; it still hits the pre-existing filesystemprovider certificate-count failure unrelated to this change.