### PR TITLE
test: update CRL test skip message for v2

### DIFF
--- a/test/bats/base-test.bats
+++ b/test/bats/base-test.bats
@@ -246,7 +246,7 @@ EOF
 }
 
 @test "notation verification pass on CRL check with audit trust policy" {
-    skip "TODO: migrate to v2 executor CRD"
+    skip "v2 notation verifier does not support configurable verification level (audit); hardcoded to strict"
     teardown() {
         echo "cleaning up"
         wait_for_process ${WAIT_TIME} ${SLEEP_TIME} 'kubectl delete pod demo --namespace default --force --ignore-not-found=true'
@@ -270,7 +270,7 @@ EOF
 }
 
 @test "notation test with certs across namespace" {
-    skip "TODO: migrate to v2 executor CRD"
+    skip "v2 executor CRD is cluster-scoped only, namespace-scoped executor not yet supported (see #2672)"
     teardown() {
         echo "cleaning up"
         wait_for_process ${WAIT_TIME} ${SLEEP_TIME} 'kubectl delete pod demo --namespace default --force --ignore-not-found=true'


### PR DESCRIPTION
## Summary
- Update skip message for "notation verification pass on CRL check with audit trust policy" test

## Reason
v2 notation verifier hardcodes `VerificationLevel: "strict"` in `initTrustPolicyDocument()` (`internal/verifier/notation/register.go:155`). The CRL test requires `audit` verification level which is not configurable in v2.

This test will remain skipped until v2 supports configurable verification levels.

## Test plan
- [x] Only skip message change, no functional impact