### PR TITLE
ci: pin e2e-aks resource group to ratify-project

### DIFF
--- a/.github/workflows/e2e-aks.yml
+++ b/.github/workflows/e2e-aks.yml
@@ -75,6 +75,9 @@ jobs:
           make e2e-dependencies
 
       - name: Run e2e on Azure
+        env:
+          GROUP_NAME: ratify-project
+          LOCATION: westus2
         run: |
           make e2e-aks KUBERNETES_VERSION=${{ inputs.k8s_version }} GATEKEEPER_VERSION=${{ inputs.gatekeeper_version }} TENANT_ID=${{ secrets.AZURE_TENANT_ID }} AZURE_SP_OBJECT_ID=${{ secrets.AZURE_SP_OBJECT_ID }}
 

--- a/scripts/azure-ci-test.sh
+++ b/scripts/azure-ci-test.sh
@@ -30,7 +30,7 @@ export ACR_NAME="${ACR_NAME:-ratifyacr${SUFFIX}}"
 export AKS_NAME="${AKS_NAME:-ratify-aks-${SUFFIX}}"
 export KEYVAULT_NAME="${KEYVAULT_NAME:-ratify-akv-${SUFFIX}}"
 export USER_ASSIGNED_IDENTITY_NAME="${USER_ASSIGNED_IDENTITY_NAME:-ratify-e2e-identity-${SUFFIX}}"
-export LOCATION="westus2"
+export LOCATION="${LOCATION:-westus2}"
 export KUBERNETES_VERSION=${1:-1.30.6}
 GATEKEEPER_VERSION=${2:-3.18.0}
 TENANT_ID=$3
@@ -157,8 +157,10 @@ cleanup() {
   echo "Purge key vault"
   az keyvault purge --name "${KEYVAULT_NAME}" --no-wait || true
 
-  echo "Deleting group"
-  az group delete --name "${GROUP_NAME}" --yes --no-wait || true
+  echo "Deleting child resources (RG is shared, do not delete)"
+  az aks      delete -g "${GROUP_NAME}" -n "${AKS_NAME}"                     --yes --no-wait || true
+  az acr      delete -g "${GROUP_NAME}" -n "${ACR_NAME}"                     --yes           || true
+  az identity delete -g "${GROUP_NAME}" -n "${USER_ASSIGNED_IDENTITY_NAME}"                  || true
 }
 
 trap cleanup EXIT

--- a/scripts/create-azure-resources.sh
+++ b/scripts/create-azure-resources.sh
@@ -114,7 +114,7 @@ create_akv() {
 }
 
 main() {
-  az group create --name "${GROUP_NAME}" --tags "ratifye2e" --location "${LOCATION}" >/dev/null
+  echo "Using existing resource group ${GROUP_NAME} in ${LOCATION}"
 
   create_user_managed_identity
   create_akv


### PR DESCRIPTION
## What this PR does

Fixes the failing `e2e-aks` workflow on `main` (e.g. [run 28991952093](https://github.com/notaryproject/ratify/actions/runs/28991952093/job/86033555403)).

## Root cause

The `Run e2e on Azure` step on `main` did not set `GROUP_NAME`. As a result:

- `scripts/azure-ci-test.sh` fell back to a random name: `GROUP_NAME=ratify-e2e-<suffix>`.
- `scripts/create-azure-resources.sh` then ran a **subscription-scoped** `az group create` for that new resource group.
- The CI service principal is scoped to the existing `ratify-project` resource group, so it lacks `Microsoft.Resources/subscriptions/resourcegroups/write` at subscription scope, failing with `AuthorizationFailed`. The EXIT-trap cleanup then produced a cascade of `delete` authorization errors, masking the real cause.

## Fix

Pin `GROUP_NAME=ratify-project` and `LOCATION=westus2` on the step, matching the working `release-1.4` workflow.

## Evidence

- `release-1.4` sets these env vars and passes consistently (runs on 2026-06-24 and 2026-06-30).
- `main` is the only branch failing, at the very first `az group create` call.