### PR TITLE
test: update K8s secrets auth test skip message

### DIFF
--- a/test/bats/base-test.bats
+++ b/test/bats/base-test.bats
@@ -580,7 +580,7 @@ EOF
 }
 
 @test "validate K8s secrets ORAS auth provider" {
-    skip "v2 e2e uses static credential provider; k8s secret auth provider not configured in current executor"
+    skip "v2 only supports static and azure credential providers; k8sSecret provider not implemented"
     teardown() {
         echo "cleaning up"
         wait_for_process ${WAIT_TIME} ${SLEEP_TIME} 'kubectl delete pod demo --namespace default --ignore-not-found=true'


### PR DESCRIPTION
## Summary
- Update skip message for K8s secrets ORAS auth provider test

## Reason
v2 credential provider registry (`internal/store/credentialprovider/`) only has `static` and `azure` providers. The `k8sSecret` provider from v1 is not implemented in v2.

## Test plan
- [x] Skip message only, no functional change