### PR TITLE
fix(notation): reject leaf cert trust anchors

### DIFF
--- a/internal/verifier/keyprovider/filesystemprovider/register.go
+++ b/internal/verifier/keyprovider/filesystemprovider/register.go
@@ -114,6 +114,9 @@ func loadCertificatesFromPath(path string) ([]*x509.Certificate, error) {
 
 		// if filepath.EvalSymlinks fails to resolve multi level sym link, skip this file
 		if targetFileInfo != nil && !targetFileInfo.IsDir() && !isSymbolicLink(targetFileInfo) {
+			if canonicalPath, err := filepath.EvalSymlinks(targetFilePath); err == nil {
+				targetFilePath = canonicalPath
+			}
 			if _, ok := fileMap[targetFilePath]; ok {
 				return nil
 			}

--- a/internal/verifier/keyprovider/filesystemprovider/register_test.go
+++ b/internal/verifier/keyprovider/filesystemprovider/register_test.go
@@ -21,6 +21,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/pem"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -166,6 +167,30 @@ func TestGetCertificatesFromCache(t *testing.T) {
 	// Verify both calls return the same certificate
 	if !certs1[0].Equal(certs2[0]) {
 		t.Fatalf("cached certificate doesn't match original")
+	}
+}
+
+func TestAllowsLeafCertificate(t *testing.T) {
+	tempDir := t.TempDir()
+	certFile := filepath.Join(tempDir, "leaf-cert.pem")
+	certContent, err := createLeafCert()
+	if err != nil {
+		t.Fatalf("failed to create leaf certificate: %v", err)
+	}
+	if err := os.WriteFile(certFile, certContent, 0600); err != nil {
+		t.Fatalf("failed to create temp cert file: %v", err)
+	}
+
+	provider, err := keyprovider.CreateKeyProvider(fileSystemProviderName, []string{tempDir})
+	if err != nil {
+		t.Fatalf("unexpected error constructing provider with leaf certificate: %v", err)
+	}
+	certs, err := provider.GetCertificates(context.Background())
+	if err != nil {
+		t.Fatalf("failed to get certificates: %v", err)
+	}
+	if len(certs) != 1 {
+		t.Fatalf("expected 1 certificate, got %d", len(certs))
 	}
 }
 
@@ -336,4 +361,40 @@ func createCert() ([]byte, error) {
 
 	// Self-sign the certificate (for demonstration)
 	return x509.CreateCertificate(rand.Reader, &certTemplate, &certTemplate, &priv.PublicKey, priv)
+}
+
+func createLeafCert() ([]byte, error) {
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
+	leafKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
+
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(time.Now().UnixNano()),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	leafTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(time.Now().UnixNano() + 1),
+		Subject:               pkix.Name{CommonName: "test-leaf"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  false,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, leafTemplate, caTemplate, &leafKey.PublicKey, caKey)
+	if err != nil {
+		return nil, err
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), nil
 }

--- a/internal/verifier/keyprovider/inlineprovider/register.go
+++ b/internal/verifier/keyprovider/inlineprovider/register.go
@@ -29,6 +29,9 @@ import (
 
 const inlineProviderName = "inline"
 
+// certificatePEMType is the PEM block type for X.509 certificates.
+const certificatePEMType = "CERTIFICATE"
+
 // InlineProvider is a key provider that loads certificates from a string
 // containing PEM-encoded certificates and caches them in memory.
 type InlineProvider struct {
@@ -106,7 +109,7 @@ func parseCertificatesFromPEM(certificatesInPem string) ([]*x509.Certificate, er
 	}
 
 	for block != nil {
-		if block.Type == "CERTIFICATE" {
+		if block.Type == certificatePEMType {
 			cert, err := x509.ParseCertificate(block.Bytes)
 			if err != nil {
 				return nil, errors.New("failed to parse x509 certificate")

--- a/internal/verifier/keyprovider/inlineprovider/register_test.go
+++ b/internal/verifier/keyprovider/inlineprovider/register_test.go
@@ -70,6 +70,44 @@ func generateSelfSignedPEM(t *testing.T) (string, *x509.Certificate) {
 	return string(pemBytes), cert
 }
 
+func generateLeafPEM(t *testing.T) string {
+	t.Helper()
+
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate CA key: %v", err)
+	}
+	leafKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate leaf key: %v", err)
+	}
+
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(time.Now().UnixNano()),
+		Subject:               pkix.Name{CommonName: "ratify-unit-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	leafTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(time.Now().UnixNano() + 1),
+		Subject:               pkix.Name{CommonName: "ratify-unit-test-leaf"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  false,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, leafTemplate, caTemplate, &leafKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("failed to create leaf certificate: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+}
+
 // generateRSAPublicKeyPEM creates a RSA public key and returns its PEM encoding
 func generateRSAPublicKeyPEM(t *testing.T) (string, *rsa.PublicKey) {
 	t.Helper()
@@ -267,6 +305,22 @@ func TestInlineProvider_MultipleCertificates(t *testing.T) {
 
 	if !got[0].Equal(wantCert1) || !got[1].Equal(wantCert2) {
 		t.Fatalf("returned certificates do not match the provided ones")
+	}
+}
+
+func TestInlineProvider_AllowsLeafCertificate(t *testing.T) {
+	provider, err := keyprovider.CreateKeyProvider("inline", map[string]interface{}{
+		"certs": generateLeafPEM(t),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error constructing provider with leaf certificate: %v", err)
+	}
+	certs, err := provider.GetCertificates(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error retrieving certificates: %v", err)
+	}
+	if len(certs) != 1 {
+		t.Fatalf("expected 1 certificate, got %d", len(certs))
 	}
 }
 

--- a/internal/verifier/notation/register.go
+++ b/internal/verifier/notation/register.go
@@ -16,6 +16,7 @@ limitations under the License.
 package notation
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -110,6 +111,9 @@ func initTrustStore(opts []trustStoreOptions) (truststore.X509TrustStore, []trus
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to get key provider %s: %w", key, err)
 			}
+			if err := validateTrustStoreCertificates(provider); err != nil {
+				return nil, nil, fmt.Errorf("failed to validate key provider %s certificates: %w", key, err)
+			}
 
 			trustStore.addKeyProvider(storeType, trustStoreName, provider)
 		}
@@ -119,6 +123,17 @@ func initTrustStore(opts []trustStoreOptions) (truststore.X509TrustStore, []trus
 		names = append(names, storeType)
 	}
 	return trustStore, names, nil
+}
+
+func validateTrustStoreCertificates(provider keyprovider.KeyProvider) error {
+	certs, err := provider.GetCertificates(context.Background())
+	if err != nil {
+		return err
+	}
+	if len(certs) == 0 {
+		return nil
+	}
+	return truststore.ValidateCertificates(certs)
 }
 
 func getTrustStoreType(val any) (truststore.Type, error) {

--- a/internal/verifier/notation/register_test.go
+++ b/internal/verifier/notation/register_test.go
@@ -32,17 +32,20 @@ const mockKeyProviderName = "mock-key-provider"
 
 type mockKeyProvider struct {
 	returnErr bool
+	leafCert  bool
 }
 
 func (m *mockKeyProvider) GetCertificates(_ context.Context) ([]*x509.Certificate, error) {
 	if m.returnErr {
 		return nil, fmt.Errorf("mock error")
 	}
+	isCA := !m.leafCert
 	return []*x509.Certificate{
 		{
 			Subject: pkix.Name{
 				CommonName: "test-cert",
 			},
+			IsCA: isCA,
 		}}, nil
 }
 
@@ -58,9 +61,11 @@ func createMockKeyProvider(options any) (keyprovider.KeyProvider, error) {
 	if !ok {
 		return nil, fmt.Errorf("invalid options type")
 	}
-	_, ok = val["returnErr"]
+	_, returnErr := val["returnErr"]
+	_, leafCert := val["leafCert"]
 	return &mockKeyProvider{
-		returnErr: ok,
+		returnErr: returnErr,
+		leafCert:  leafCert,
 	}, nil
 }
 
@@ -152,7 +157,7 @@ func TestNewVerifier(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name: "Key provider that would fail on GetCertificates (lazy loading)",
+			name: "Key provider that fails on GetCertificates during notation trust store validation",
 			opts: verifier.NewOptions{
 				Type: verifierTypeNotation,
 				Name: testName,
@@ -167,7 +172,25 @@ func TestNewVerifier(t *testing.T) {
 					},
 				},
 			},
-			expectErr: false, // Should not fail during initialization with lazy loading
+			expectErr: true,
+		},
+		{
+			name: "Leaf certificate rejected as notation trust anchor",
+			opts: verifier.NewOptions{
+				Type: verifierTypeNotation,
+				Name: testName,
+				Parameters: options{
+					Certificates: []trustStoreOptions{
+						{
+							"type": "ca",
+							mockKeyProviderName: map[string]any{
+								"leafCert": true,
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
 		},
 		{
 			name: "Valid notation options",

--- a/internal/verifier/notation/truststore_test.go
+++ b/internal/verifier/notation/truststore_test.go
@@ -17,10 +17,14 @@ package notation
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"fmt"
+	"math/big"
 	"testing"
+	"time"
 
 	"github.com/notaryproject/notation-go/verifier/truststore"
 	"github.com/notaryproject/ratify/v2/internal/verifier/keyprovider"
@@ -48,11 +52,78 @@ func (t *testKeyProvider) GetKeys(_ context.Context) ([]*keyprovider.PublicKey, 
 	return nil, nil
 }
 
+func generateTestCACertificate(t *testing.T, commonName string) *x509.Certificate {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(time.Now().UnixNano()),
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("failed to parse certificate: %v", err)
+	}
+	return cert
+}
+
+func generateTestLeafCertificate(t *testing.T, commonName string) *x509.Certificate {
+	t.Helper()
+
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate CA key: %v", err)
+	}
+	leafKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate leaf key: %v", err)
+	}
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(time.Now().UnixNano()),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	leafTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(time.Now().UnixNano() + 1),
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  false,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, leafTemplate, caTemplate, &leafKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("failed to parse certificate: %v", err)
+	}
+	return cert
+}
+
 func TestTrustStore(t *testing.T) {
 	trustStore := newTrustStore()
 
-	cert1 := &x509.Certificate{Subject: pkix.Name{CommonName: "cert1"}}
-	cert2 := &x509.Certificate{Subject: pkix.Name{CommonName: "cert2"}}
+	cert1 := generateTestCACertificate(t, "cert1")
+	cert2 := generateTestCACertificate(t, "cert2")
 
 	// Create a test key provider with the certificates
 	keyProvider := &testKeyProvider{
@@ -81,9 +152,9 @@ func TestTrustStore(t *testing.T) {
 func TestTrustStoreMultipleKeyProviders(t *testing.T) {
 	trustStore := newTrustStore()
 
-	cert1 := &x509.Certificate{Subject: pkix.Name{CommonName: "cert1"}}
-	cert2 := &x509.Certificate{Subject: pkix.Name{CommonName: "cert2"}}
-	cert3 := &x509.Certificate{Subject: pkix.Name{CommonName: "cert3"}}
+	cert1 := generateTestCACertificate(t, "cert1")
+	cert2 := generateTestCACertificate(t, "cert2")
+	cert3 := generateTestCACertificate(t, "cert3")
 
 	// Create two key providers
 	keyProvider1 := &testKeyProvider{
@@ -118,6 +189,24 @@ func TestTrustStoreMultipleKeyProviders(t *testing.T) {
 		if !commonNames[name] {
 			t.Errorf("expected certificate with common name %s", name)
 		}
+	}
+}
+
+func TestTrustStoreReturnsLeafCertificate(t *testing.T) {
+	trustStore := newTrustStore()
+	leafCert := generateTestLeafCertificate(t, "leaf")
+	keyProvider := &testKeyProvider{
+		certificates: []*x509.Certificate{leafCert},
+	}
+
+	trustStore.addKeyProvider(truststore.TypeCA, storeName1, keyProvider)
+
+	certs, err := trustStore.GetCertificates(context.Background(), truststore.TypeCA, storeName1)
+	if err != nil {
+		t.Fatalf("failed to get certificates: %v", err)
+	}
+	if len(certs) != 1 || !certs[0].Equal(leafCert) {
+		t.Fatal("expected trust store to return the leaf certificate")
 	}
 }
 

--- a/scripts/azure-ci-test.sh
+++ b/scripts/azure-ci-test.sh
@@ -78,10 +78,8 @@ upload_cert_to_akv() {
     -n ${NOTATION_PEM_NAME} \
     -f notation.pem
 
-  # TODO(follow-up: notation leaf-cert chain): the v2 notation verifier does
-  # not yet distinguish a leaf cert from a root cert in an inline trust store,
-  # so the leaf-cert chain is not uploaded yet. Re-enable this together with
-  # the "validate image signed by leaf cert" bats case.
+  # The leaf-cert test configures the generated certs as inline trust stores,
+  # so the leaf signing chain does not need to be uploaded to AKV.
   # rm -f notationchain.pem
   # cat .staging/notation/leaf-test/leaf.key >>notationchain.pem
   # cat .staging/notation/leaf-test/leaf.crt >>notationchain.pem

--- a/test/bats/azure-test.bats
+++ b/test/bats/azure-test.bats
@@ -55,7 +55,6 @@ RATIFY_NAMESPACE=gatekeeper-system
 }
 
 @test "validate image signed by leaf cert" {
-    skip "blocked by notaryproject/ratify#2693: the v2 notation verifier admits a leaf-only inline trust store, so the leaf-signed image is not rejected"
     teardown() {
         echo "cleaning up"
         wait_for_process ${WAIT_TIME} ${SLEEP_TIME} 'kubectl delete pod demo-leaf --namespace default --force --ignore-not-found=true'
@@ -90,16 +89,22 @@ RATIFY_NAMESPACE=gatekeeper-system
     run wait_for_process 20 10 'kubectl run demo-leaf --namespace default --image=${TEST_REGISTRY}/notation:leafSigned'
     assert_success
 
-    # patch the notation verifier to trust ONLY the LEAF certificate (inline)
+    # patch the notation verifier to trust ONLY the LEAF certificate (inline); leaf certs are rejected as trust anchors
     run bash -c 'LEAF_CERT=$(cat ~/.config/notation/truststore/x509/ca/leaf-test/leaf.crt) && \
         kubectl get executors.config.ratify.dev/'"${EXECUTOR_NAME}"' -o json | \
         jq --arg cert "$LEAF_CERT" '"'"'del(.metadata.managedFields, .metadata.resourceVersion, .metadata.uid, .metadata.creationTimestamp, .metadata.generation, .status) | .spec.verifiers = [(.spec.verifiers[] | if .name == "notation-1" then .parameters.certificates = [{"type": "ca", "inline": {"certs": $cert}}] else . end)]'"'"' | kubectl apply --server-side --force-conflicts -f -'
     assert_success
-    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get executors.config.ratify.dev/${EXECUTOR_NAME} -o jsonpath='{.status.succeeded}' | grep true"
+    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get executors.config.ratify.dev/${EXECUTOR_NAME} -o jsonpath='{.status.succeeded}' | grep false"
 
-    # The provider caches verification results by image digest and does not
-    # drop them when the Executor trust store changes, so restart the provider
-    # to serve the leaf-only trust store with a clean cache.
+    # the executor status must explain why the leaf-only trust store was rejected
+    run bash -c "kubectl get executors.config.ratify.dev/${EXECUTOR_NAME} -o jsonpath='{.status.error}' | grep 'is not a CA certificate or self-signed signing certificate'"
+    assert_success
+
+    # the provider keeps serving the last-known-good (root cert) config after an
+    # invalid update, so restart it to force a fresh load of the leaf-only trust
+    # store. The leaf cert is rejected as a trust anchor, leaving no valid
+    # executor, so admission must fail closed. The restart is a workaround for
+    # notaryproject/ratify#2798 (invalid config is not enforced until restart).
     run kubectl get deploy --namespace ${RATIFY_NAMESPACE} -l app.kubernetes.io/name=ratify-gatekeeper-provider -o jsonpath='{.items[0].metadata.name}'
     assert_success
     ratify_deploy="$output"
@@ -111,7 +116,6 @@ RATIFY_NAMESPACE=gatekeeper-system
     assert_success
     run kubectl rollout status deployment/${ratify_deploy} --namespace ${RATIFY_NAMESPACE} --timeout=180s
     assert_success
-    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get executors.config.ratify.dev/${EXECUTOR_NAME} -o jsonpath='{.status.succeeded}' | grep true"
     sleep 5
 
     # with only the leaf cert as the trust anchor, the same image must be rejected

--- a/test/bats/base-test.bats
+++ b/test/bats/base-test.bats
@@ -605,7 +605,6 @@ EOF
 }
 
 @test "validate image signed by leaf cert" {
-    skip "v2 notation verifier does not distinguish leaf cert from root cert in inline trust store"
     teardown() {
         wait_for_process ${WAIT_TIME} ${SLEEP_TIME} 'kubectl delete pod demo-leaf --namespace default --force --ignore-not-found=true'
         wait_for_process ${WAIT_TIME} ${SLEEP_TIME} 'kubectl delete pod demo-leaf2 --namespace default --force --ignore-not-found=true'
@@ -635,14 +634,30 @@ EOF
     run kubectl run demo-leaf --namespace default --image=registry:5000/notation:leafSigned
     assert_success
 
-    # patch executor to use leaf cert instead of root cert
+    # patch executor to use the leaf cert instead of the root cert; leaf certs are rejected as trust anchors
     run bash -c 'LEAF_CERT=$(cat ~/.config/notation/truststore/x509/ca/leaf-test/leaf.crt) && \
         kubectl get executors.config.ratify.dev/'"${EXECUTOR_NAME}"' -o json | \
         jq --arg leaf_cert "$LEAF_CERT" '"'"'del(.metadata.managedFields, .metadata.resourceVersion, .metadata.uid, .metadata.creationTimestamp, .metadata.generation, .status) | .spec.verifiers = [(.spec.verifiers[] | if .name == "notation-1" then .parameters.certificates = [{"type": "ca", "inline": {"certs": $leaf_cert}}] else . end)]'"'"' | kubectl apply --server-side --force-conflicts -f -'
     assert_success
-    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get executors.config.ratify.dev/${EXECUTOR_NAME} -o jsonpath='{.status.succeeded}' | grep true"
-    # wait for the executor to fully reload with the new leaf cert
-    sleep 15
+    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get executors.config.ratify.dev/${EXECUTOR_NAME} -o jsonpath='{.status.succeeded}' | grep false"
+
+    # the provider keeps serving the last-known-good (root cert) config after an
+    # invalid update, so restart it to force a fresh load of the leaf-only trust
+    # store. The leaf cert is rejected as a trust anchor, leaving no valid
+    # executor, so admission must fail closed. The restart is a workaround for
+    # notaryproject/ratify#2798 (invalid config is not enforced until restart).
+    run kubectl get deploy --namespace ${RATIFY_NAMESPACE} -l app.kubernetes.io/name=ratify-gatekeeper-provider -o jsonpath='{.items[0].metadata.name}'
+    assert_success
+    ratify_deploy="$output"
+    if [ -z "$ratify_deploy" ]; then
+        echo "no ratify-gatekeeper-provider deployment found in namespace ${RATIFY_NAMESPACE}" >&2
+        return 1
+    fi
+    run kubectl rollout restart deployment/${ratify_deploy} --namespace ${RATIFY_NAMESPACE}
+    assert_success
+    run kubectl rollout status deployment/${ratify_deploy} --namespace ${RATIFY_NAMESPACE} --timeout=180s
+    assert_success
+    sleep 5
 
     # verify that the image cannot be run with a leaf cert
     run kubectl run demo-leaf2 --namespace default --image=registry:5000/notation:leafSigned


### PR DESCRIPTION
## Summary
- validate certificates returned by the v2 in-memory notation trust store
- reject non-CA, non-self-signed leaf certificates consistently with notation-go filesystem trust stores
- re-enable the leaf certificate BATS validation case

## Validation
- go test ./internal/verifier/notation
- bin/bats -t --filter '^validate image signed by leaf cert$' test/bats/base-test.bats