### PR TITLE
ci: validate published image before chart publish

### DIFF
--- a/.github/workflows/e2e-k8s.yml
+++ b/.github/workflows/e2e-k8s.yml
@@ -16,6 +16,16 @@ on:
         required: true
         default: "3.18.0"
         type: string
+      ratify_image_repository:
+        description: "Ratify image repository used by the Helm chart"
+        required: false
+        default: "localbuild"
+        type: string
+      ratify_image_tag:
+        description: "Ratify image tag used by the Helm chart"
+        required: false
+        default: "test"
+        type: string
   workflow_call:
     inputs:
       k8s_version:
@@ -27,6 +37,16 @@ on:
         description: "Gatekeeper version"
         required: true
         default: "3.18.0"
+        type: string
+      ratify_image_repository:
+        description: "Ratify image repository used by the Helm chart"
+        required: false
+        default: "localbuild"
+        type: string
+      ratify_image_tag:
+        description: "Ratify image tag used by the Helm chart"
+        required: false
+        default: "test"
         type: string
 
 jobs:
@@ -59,7 +79,10 @@ jobs:
       - name: Run e2e with config policy
         run: |
           make e2e-deploy-gatekeeper GATEKEEPER_VERSION=${{ inputs.gatekeeper_version }}
-          make e2e-deploy-ratify GATEKEEPER_VERSION=${{ inputs.gatekeeper_version }}
+          make e2e-deploy-ratify \
+            GATEKEEPER_VERSION=${{ inputs.gatekeeper_version }} \
+            E2E_RATIFY_IMAGE_REPOSITORY=${{ inputs.ratify_image_repository }} \
+            E2E_RATIFY_IMAGE_TAG=${{ inputs.ratify_image_tag }}
           make test-e2e GATEKEEPER_VERSION=${{ inputs.gatekeeper_version }}
       - name: Save logs
         if: ${{ always() }}
@@ -72,10 +95,10 @@ jobs:
       - name: Save logs
         if: ${{ always() }}
         run: |
-          kubectl logs -n gatekeeper-system -l control-plane=controller-manager --tail=-1 > logs-externaldata-controller-${{ matrix.KUBERNETES_VERSION }}-${{ matrix.GATEKEEPER_VERSION }}.json
-          kubectl logs -n gatekeeper-system -l control-plane=audit-controller --tail=-1 > logs-externaldata-audit-${{ matrix.KUBERNETES_VERSION }}-${{ matrix.GATEKEEPER_VERSION }}.json
-          kubectl logs -n gatekeeper-system -l app=ratify --tail=-1 > logs-ratify-preinstall-${{ matrix.KUBERNETES_VERSION }}-${{ matrix.GATEKEEPER_VERSION }}-rego-policy.json
-          kubectl logs -n gatekeeper-system -l app.kubernetes.io/name=ratify --tail=-1 > logs-ratify-${{ matrix.KUBERNETES_VERSION }}-${{ matrix.GATEKEEPER_VERSION }}-rego-policy.json
+          kubectl logs -n gatekeeper-system -l control-plane=controller-manager --tail=-1 > logs-externaldata-controller-${{ inputs.k8s_version }}-${{ inputs.gatekeeper_version }}.json
+          kubectl logs -n gatekeeper-system -l control-plane=audit-controller --tail=-1 > logs-externaldata-audit-${{ inputs.k8s_version }}-${{ inputs.gatekeeper_version }}.json
+          kubectl logs -n gatekeeper-system -l app=ratify --tail=-1 > logs-ratify-preinstall-${{ inputs.k8s_version }}-${{ inputs.gatekeeper_version }}-rego-policy.json
+          kubectl logs -n gatekeeper-system -l app.kubernetes.io/name=ratify --tail=-1 > logs-ratify-${{ inputs.k8s_version }}-${{ inputs.gatekeeper_version }}-rego-policy.json
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ always() }}

--- a/.github/workflows/publish-charts.yml
+++ b/.github/workflows/publish-charts.yml
@@ -1,8 +1,6 @@
 name: publishChart
 on:
-  push:
-    tags:
-      - v*
+  workflow_dispatch:
 
 permissions: read-all
 

--- a/.github/workflows/publish-dev-charts.yml
+++ b/.github/workflows/publish-dev-charts.yml
@@ -1,8 +1,5 @@
 name: publish-dev-chart
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 permissions: read-all

--- a/.github/workflows/publish-dev-package.yml
+++ b/.github/workflows/publish-dev-package.yml
@@ -11,6 +11,10 @@ permissions: read-all
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      image_ref: ${{ steps.prepare.outputs.ref }}
+      image_repository: ${{ steps.prepare.outputs.repository }}
+      image_tag: ${{ steps.prepare.outputs.version }}
     permissions:
       packages: write
       contents: read
@@ -45,6 +49,8 @@ jobs:
         run: |
           ORG_NAME=$(echo "$GITHUB_REPOSITORY" | cut -d'/' -f1)
           REPOSITORY=ghcr.io/${ORG_NAME}/ratify-gatekeeper-provider
+          echo "version=dev" >> $GITHUB_OUTPUT
+          echo "repository=${REPOSITORY}" >> $GITHUB_OUTPUT
           echo "ref=${REPOSITORY}:dev" >> $GITHUB_OUTPUT
       - name: docker login
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
@@ -82,3 +88,34 @@ jobs:
         if: always()
         run: |
           rm -f ${HOME}/.docker/config.json
+
+  e2e:
+    name: Run e2e with published image and current chart
+    needs: build
+    uses: ./.github/workflows/e2e-k8s.yml
+    with:
+      k8s_version: "1.31.2"
+      gatekeeper_version: "3.18.0"
+      ratify_image_repository: ${{ needs.build.outputs.image_repository }}
+      ratify_image_tag: ${{ needs.build.outputs.image_tag }}
+
+  publish-chart:
+    name: Publish Helm charts
+    needs: e2e
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+      - name: Publish Helm charts
+        uses: stefanprodan/helm-gh-pages@0ad2bb377311d61ac04ad9eb6f252fb68e207260 # v1.7.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          charts_dir: deployments

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -11,6 +11,10 @@ permissions: read-all
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      image_ref: ${{ steps.prepare.outputs.ref }}
+      image_repository: ${{ steps.prepare.outputs.repository }}
+      image_tag: ${{ steps.prepare.outputs.version }}
     permissions:
       packages: write
       contents: read
@@ -51,6 +55,7 @@ jobs:
             VERSION=$(git rev-parse --short HEAD)
           fi
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "repository=${REPOSITORY}" >> $GITHUB_OUTPUT
           echo "ref=${REPOSITORY}:${VERSION}" >> $GITHUB_OUTPUT
       - name: Get tag
         run: |
@@ -91,3 +96,34 @@ jobs:
         if: always()
         run: |
           rm -f ${HOME}/.docker/config.json
+
+  e2e:
+    name: Run e2e with published image and current chart
+    needs: build
+    uses: ./.github/workflows/e2e-k8s.yml
+    with:
+      k8s_version: "1.31.2"
+      gatekeeper_version: "3.18.0"
+      ratify_image_repository: ${{ needs.build.outputs.image_repository }}
+      ratify_image_tag: ${{ needs.build.outputs.image_tag }}
+
+  publish-chart:
+    name: Publish Helm charts
+    needs: e2e
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+      - name: Publish Helm charts
+        uses: stefanprodan/helm-gh-pages@0ad2bb377311d61ac04ad9eb6f252fb68e207260 # v1.7.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          charts_dir: deployments


### PR DESCRIPTION
## Summary

Gate Helm chart publishing behind a k8s e2e run against the exact image that was just published, for both the tag-release flow and the main-branch dev flow.

**Reusable e2e workflow (`e2e-k8s.yml`)**
- Expose optional `ratify_image_repository` / `ratify_image_tag` inputs (on both `workflow_dispatch` and `workflow_call`) so callers can point the e2e at a specific published image; defaults keep the existing `localbuild:test` behaviour.
- Pass them through to `make e2e-deploy-ratify` via `E2E_RATIFY_IMAGE_REPOSITORY` / `E2E_RATIFY_IMAGE_TAG`.
- Fix log-artifact filenames to use `inputs.k8s_version` / `inputs.gatekeeper_version` (the old `matrix.*` refs are undefined in this workflow).

**Tag release (`publish-package.yml` + `publish-charts.yml`)**
- Export the built image repository/tag as job outputs from `build`.
- Add an `e2e` job that runs `e2e-k8s.yml` against the just-published GHCR image and current chart.
- Add a `publish-chart` job that publishes Helm charts only after `e2e` succeeds.
- Switch `publish-charts.yml` to `workflow_dispatch` only, removing the `v*` tag trigger so charts are no longer published in parallel with the image build.

**Dev release (`publish-dev-package.yml` + `publish-dev-charts.yml`)**
- Same restructuring for main-branch pushes: export image outputs, run `e2e` against the just-published `:dev` image, and publish dev charts only after e2e passes.
- Switch `publish-dev-charts.yml` to `workflow_dispatch` only, removing the `push: main` trigger.

## Validation
- Parsed all modified workflow YAML files with a YAML parser.
- `git diff --check`.

## Notes
- This changes release ordering: chart publishing now depends on a successful e2e run instead of firing on the tag/branch push directly.