### PR TITLE
chore: dependentbot only check dev branch and add cve bump for release-1.4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,7 +58,7 @@ updates:
     labels:
       - "v2"
 
-  # ---------- release-1.4 branch ----------
+  # ---------- v1-dev branch ----------
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: "v1-dev"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       interval: "daily"
     commit-message:
       prefix: "chore"
+    labels:
+      - "v2"
 
   - package-ecosystem: "gomod"
     directory: "/"
@@ -15,6 +17,8 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore"
+    labels:
+      - "v2"
     ignore:
       - dependency-name: "*"
         update-types:
@@ -27,6 +31,8 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore"
+    labels:
+      - "v2"
 
   - package-ecosystem: "docker"
     directory: "/httpserver"
@@ -37,6 +43,8 @@ updates:
         versions: '> 1.22'
     commit-message:
       prefix: "chore"
+    labels:
+      - "v2"
 
   - package-ecosystem: "docker"
     directory: "/.devcontainer"
@@ -47,29 +55,31 @@ updates:
         versions: '> 1.22'
     commit-message:
       prefix: "chore"
+    labels:
+      - "v2"
 
   # ---------- release-1.4 branch ----------
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "release-1.4"
+    target-branch: "v1-dev"
     schedule:
       interval: "daily"
     commit-message:
       prefix: "chore"
     labels:
       - "dependencies"
-      - "release-1.4"
+      - "v1"
 
   - package-ecosystem: "gomod"
     directory: "/"
-    target-branch: "release-1.4"
+    target-branch: "v1-dev"
     schedule:
       interval: "weekly"
     commit-message:
       prefix: "chore"
     labels:
       - "dependencies"
-      - "release-1.4"
+      - "v1"
     ignore:
       - dependency-name: "*"
         update-types:
@@ -78,18 +88,18 @@ updates:
 
   - package-ecosystem: "docker"
     directory: "/"
-    target-branch: "release-1.4"
+    target-branch: "v1-dev"
     schedule:
       interval: "weekly"
     commit-message:
       prefix: "chore"
     labels:
       - "dependencies"
-      - "release-1.4"
+      - "v1"
 
   - package-ecosystem: "docker"
     directory: "/httpserver"
-    target-branch: "release-1.4"
+    target-branch: "v1-dev"
     schedule:
       interval: "weekly"
     ignore:
@@ -99,11 +109,11 @@ updates:
       prefix: "chore"
     labels:
       - "dependencies"
-      - "release-1.4"
+      - "v1"
 
   - package-ecosystem: "docker"
     directory: "/.devcontainer"
-    target-branch: "release-1.4"
+    target-branch: "v1-dev"
     schedule:
       interval: "weekly"
     ignore:
@@ -113,4 +123,4 @@ updates:
       prefix: "chore"
     labels:
       - "dependencies"
-      - "release-1.4"
+      - "v1"

--- a/.github/workflows/cve-auto-bump.yml
+++ b/.github/workflows/cve-auto-bump.yml
@@ -6,14 +6,16 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   cve-bump:
     name: "Scan CVEs and auto-bump (${{ matrix.branch }})"
     runs-on: ubuntu-22.04
     timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
     strategy:
       fail-fast: false
       matrix:
@@ -112,8 +114,10 @@ jobs:
           ")
 
           if [ -z "$MODULES" ]; then
-            echo "Could not parse vulnerable modules."
-            exit 0
+            echo "Vulnerabilities were detected but affected modules could not be parsed."
+            echo "Refusing to open a pull request on incomplete data; failing the job for manual review."
+            echo "has_vulns=false" >> "$GITHUB_OUTPUT"
+            exit 1
           fi
 
           echo "Affected modules:"
@@ -128,7 +132,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.vulncheck.outputs.has_vulns == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
           branch: security/cve-bump-${{ matrix.branch }}
           base: ${{ matrix.branch }}

--- a/.github/workflows/cve-auto-bump.yml
+++ b/.github/workflows/cve-auto-bump.yml
@@ -1,0 +1,147 @@
+name: CVE Auto Bump
+
+on:
+  schedule:
+    - cron: "0 9 * * 1" # every Monday 09:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  cve-bump:
+    name: "Scan CVEs and auto-bump (${{ matrix.branch }})"
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: [release-1.4]
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout ${{ matrix.branch }}
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: ${{ matrix.branch }}
+
+      - name: Setup Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: "1.26"
+          check-latest: true
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck and bump vulnerable packages
+        id: vulncheck
+        run: |
+          set +e
+          govulncheck -format json ./... > vulncheck_output.json 2>&1
+          VULN_EXIT=$?
+          set -e
+
+          if [ $VULN_EXIT -eq 0 ]; then
+            echo "No vulnerabilities found."
+            echo "has_vulns=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Vulnerabilities detected. Extracting affected modules..."
+          echo "has_vulns=true" >> "$GITHUB_OUTPUT"
+
+          # Extract CVE IDs
+          CVE_IDS=$(cat vulncheck_output.json | \
+            python3 -c "
+          import json, sys
+
+          cves = set()
+          for line in sys.stdin:
+              line = line.strip()
+              if not line:
+                  continue
+              try:
+                  entry = json.loads(line)
+              except json.JSONDecodeError:
+                  continue
+              if 'osv' in entry:
+                  for alias in entry['osv'].get('aliases', []):
+                      if alias.startswith('CVE-'):
+                          cves.add(alias)
+          for c in sorted(cves):
+              print(c)
+          ")
+          echo "CVE IDs: $CVE_IDS"
+          # Format for PR title (comma-separated)
+          CVE_LIST=$(echo "$CVE_IDS" | paste -sd ',' - | sed 's/,/, /g')
+          echo "cve_list=$CVE_LIST" >> "$GITHUB_OUTPUT"
+
+          MODULES=$(cat vulncheck_output.json | \
+            python3 -c "
+          import json, sys
+
+          modules = set()
+          for line in sys.stdin:
+              line = line.strip()
+              if not line:
+                  continue
+              try:
+                  entry = json.loads(line)
+              except json.JSONDecodeError:
+                  continue
+              if 'finding' in entry:
+                  finding = entry['finding']
+                  if 'trace' in finding:
+                      for t in finding['trace']:
+                          if 'module' in t:
+                              modules.add(t['module'])
+              if 'osv' in entry:
+                  osv = entry['osv']
+                  for affected in osv.get('affected', []):
+                      pkg = affected.get('package', {})
+                      if 'name' in pkg:
+                          modules.add(pkg['name'])
+          for m in sorted(modules):
+              if not m.startswith('stdlib') and '.' in m:
+                  print(m)
+          ")
+
+          if [ -z "$MODULES" ]; then
+            echo "Could not parse vulnerable modules."
+            exit 0
+          fi
+
+          echo "Affected modules:"
+          echo "$MODULES"
+
+          while IFS= read -r mod; do
+            echo "Updating $mod ..."
+            go get "$mod@latest" || echo "Warning: failed to update $mod"
+          done <<< "$MODULES"
+
+          go mod tidy
+
+      - name: Create Pull Request
+        if: steps.vulncheck.outputs.has_vulns == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: security/cve-bump-${{ matrix.branch }}
+          base: ${{ matrix.branch }}
+          title: "chore: Bump vulnerable dependencies (${{ matrix.branch }}) [${{ steps.vulncheck.outputs.cve_list }}]"
+          labels: |
+            cve
+            ${{ matrix.branch }}
+          commit-message: "chore: bump vulnerable dependencies detected by govulncheck"
+          body: |
+            ## Security: Auto-bump vulnerable dependencies
+
+            `govulncheck` detected vulnerabilities on the `${{ matrix.branch }}` branch.
+            This PR updates the affected dependencies to their latest versions.
+
+            > ⚠️ Please review the changes and ensure CI passes before merging.
+          delete-branch: true

--- a/.github/workflows/cve-auto-bump.yml
+++ b/.github/workflows/cve-auto-bump.yml
@@ -38,7 +38,7 @@ jobs:
           check-latest: true
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.6.0
 
       - name: Run govulncheck and bump vulnerable packages
         id: vulncheck


### PR DESCRIPTION

## Description

release branch should only accept cve and bug fix. dependentbot should focus on v1-dev.

The new ci cve auto bump will raise one pr to fix cve for release-1.4
sample:
https://github.com/fseldow/ratify/pull/6

### Which issue(s) does this PR resolve?

<!--
    Use `Fixes #<issue number>[, Fixes #<issue_number>, ...]` format.
    Use `Fixes` for bug fixes and `Resolves` for new features.
    The PR will close the issue(s) when it gets merged.
-->
Fixes #

### Type of change

<!-- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Helm chart change (any edit/addition/update that is necessary for changes merged to the `main` branch)
- This change requires a documentation update

## Testing and verification

<!-- Please describe the tests you ran to verify your changes, including any relevant configuration details. -->

## Checklist

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?

## Post merge requirements

- [ ] MAINTAINERS: manually trigger the "Publish Package" workflow after merging any PR that indicates `Helm Chart Change`
