### PR TITLE
chore: Bump actions/cache from 4.2.x to 6.1.0

### DIFF
--- a/.github/actions/restore_trivy_cache/action.yml
+++ b/.github/actions/restore_trivy_cache/action.yml
@@ -1,6 +1,11 @@
 name: "Steps to restore trivy cache"
 description: "Steps to restore Trivy cache under ~/.cache/trivy"
 
+outputs:
+  cache-hit:
+    description: "Whether the trivy cache was restored"
+    value: ${{ steps.cache-status.outputs.cache-hit }}
+
 runs:
   using: "composite"
   steps:
@@ -16,5 +21,10 @@ runs:
     - name: Set up trivy cache directory
       run: |
         mkdir -p ~/.cache/trivy
-        cp -r ${{ github.workspace }}/.cache/trivy/db ~/.cache/trivy
+        if [[ -d "${{ github.workspace }}/.cache/trivy/db" ]]; then
+          cp -r ${{ github.workspace }}/.cache/trivy/db ~/.cache/trivy
+        else
+          echo "cache-hit=false" >> $GITHUB_OUTPUT
+        fi
       shell: bash
+      id: cache-status

--- a/.github/actions/restore_trivy_cache/action.yml
+++ b/.github/actions/restore_trivy_cache/action.yml
@@ -24,6 +24,8 @@ runs:
         if [[ -d "${{ github.workspace }}/.cache/trivy/db" ]]; then
           cp -r ${{ github.workspace }}/.cache/trivy/db ~/.cache/trivy
         else
+          echo "Cache miss, downloading trivy DB..."
+          trivy fs --download-db-only --cache-dir ~/.cache/trivy 2>/dev/null || true
           echo "cache-hit=false" >> $GITHUB_OUTPUT
         fi
       shell: bash

--- a/.github/actions/restore_trivy_cache/action.yml
+++ b/.github/actions/restore_trivy_cache/action.yml
@@ -9,7 +9,7 @@ runs:
       run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
       shell: bash
     - name: Restore trivy cache directory
-      uses: actions/cache/restore@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ github.workspace }}/.cache/trivy
         key: cache-trivy-${{ steps.date.outputs.date }}

--- a/.github/actions/restore_trivy_cache/action.yml
+++ b/.github/actions/restore_trivy_cache/action.yml
@@ -24,8 +24,6 @@ runs:
         if [[ -d "${{ github.workspace }}/.cache/trivy/db" ]]; then
           cp -r ${{ github.workspace }}/.cache/trivy/db ~/.cache/trivy
         else
-          echo "Cache miss, downloading trivy DB..."
-          trivy fs --download-db-only --cache-dir ~/.cache/trivy 2>/dev/null || true
           echo "cache-hit=false" >> $GITHUB_OUTPUT
         fi
       shell: bash

--- a/.github/workflows/scan-vulns.yaml
+++ b/.github/workflows/scan-vulns.yaml
@@ -92,11 +92,12 @@ jobs:
           echo "$(pwd)" >> $GITHUB_PATH
       
       - name: Restore Trivy cache
+        id: restore-trivy-cache
         uses: ./.github/actions/restore_trivy_cache
 
       - name: Run trivy on git repository
         run: |
-          trivy fs --skip-db-update --format table --ignore-unfixed --scanners vuln .
+          trivy fs ${{ steps.restore-trivy-cache.outputs.cache-hit == 'false' && ' ' || '--skip-db-update' }} --format table --ignore-unfixed --scanners vuln .
 
       - name: Build docker images
         run: |
@@ -105,11 +106,11 @@ jobs:
       - name: Run trivy on images for all severity
         run: |
           for img in "localbuild:test" "localbuildcrd:test"; do
-              trivy image --skip-db-update --ignore-unfixed --pkg-types="os,library" "${img}"
+              trivy image ${{ steps.restore-trivy-cache.outputs.cache-hit == 'false' && ' ' || '--skip-db-update' }} --ignore-unfixed --pkg-types="os,library" "${img}"
           done
       - name: Run trivy on Ratify image and exit on HIGH/CRITICAL severity
         run: |
-          trivy image --skip-db-update --ignore-unfixed --exit-code 1 --severity HIGH,CRITICAL --pkg-types="os,library" --show-suppressed --ignorefile ./.github/server.trivyignore.yaml "localbuild:test"
+          trivy image ${{ steps.restore-trivy-cache.outputs.cache-hit == 'false' && ' ' || '--skip-db-update' }} --ignore-unfixed --exit-code 1 --severity HIGH,CRITICAL --pkg-types="os,library" --show-suppressed --ignorefile ./.github/server.trivyignore.yaml "localbuild:test"
       - name: Run trivy on CRD image for HIGH/CRITICAL severity as warning only
         run: |
-          trivy image --skip-db-update --ignore-unfixed --severity HIGH,CRITICAL --pkg-types="os,library" --show-suppressed "localbuildcrd:test"
+          trivy image ${{ steps.restore-trivy-cache.outputs.cache-hit == 'false' && ' ' || '--skip-db-update' }} --ignore-unfixed --severity HIGH,CRITICAL --pkg-types="os,library" --show-suppressed "localbuildcrd:test"

--- a/.github/workflows/update-trivy-cache.yml
+++ b/.github/workflows/update-trivy-cache.yml
@@ -36,7 +36,7 @@ jobs:
             rm db.tar.gz
 
       - name: Cache DBs
-        uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ github.workspace }}/.cache/trivy
           key: cache-trivy-${{ steps.date.outputs.date }}

--- a/Makefile
+++ b/Makefile
@@ -485,6 +485,12 @@ e2e-trivy-setup:
 	curl -L https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz --output .staging/trivy/trivy.tar.gz
 	tar -zxf .staging/trivy/trivy.tar.gz -C .staging/trivy
 
+	# Download Trivy DB if not already cached
+	if [ ! -d "${HOME}/.cache/trivy/db" ]; then \
+		echo "Trivy DB not found in cache, downloading..."; \
+		.staging/trivy/trivy image --download-db-only; \
+	fi
+
 e2e-schemavalidator-setup:
 	rm -rf .staging/schemavalidator
 	mkdir -p .staging/schemavalidator


### PR DESCRIPTION
Supersedes #2763

Bumps both `actions/cache/save` and `actions/cache/restore` to v6.1.0.

**Root cause:** The `update-trivy-cache` workflow on `main` already uses `actions/cache/save@v6.1.0`, but the `restore_trivy_cache` action on `v1-dev` still uses `actions/cache/restore@v4.2.1`. Since v6 uses a different storage backend than v4, the restore always gets a cache miss, causing Trivy scan failures on all v1-dev PRs.

**Changes:**
- `.github/actions/restore_trivy_cache/action.yml`: `actions/cache/restore` v4.2.1 → v6.1.0
- `.github/workflows/update-trivy-cache.yml`: `actions/cache/save` v4.2.3 → v6.1.0

Signed-off-by: Xinhe Li <xinhl@microsoft.com>