### PR TITLE
ci: label PRs based on target branch

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,11 @@
+# Configuration for actions/labeler
+# Labels PRs based on the branch they target (base branch).
+# See: https://github.com/actions/labeler
+
+# PRs targeting the v1-dev branch are labeled "v1"
+v1:
+  - base-branch: ['^v1-dev$']
+
+# PRs targeting the main branch are labeled "v2"
+v2:
+  - base-branch: ['^main$']

--- a/.github/workflows/target-branch-labeler.yml
+++ b/.github/workflows/target-branch-labeler.yml
@@ -1,0 +1,26 @@
+name: target_branch_labeler
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited]
+
+permissions:
+  contents: read
+
+jobs:
+  label:
+    name: Label PR by target branch
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Label based on target branch
+        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+        with:
+          sync-labels: true


### PR DESCRIPTION
## Description

Adds automatic PR labeling based on the **target (base) branch** using [`actions/labeler@v5`](https://github.com/actions/labeler), which supports `base-branch` matching.

Mapping:
- PRs targeting `v1-dev` → label **`v1`**
- PRs targeting `main` → label **`v2`**

Both labels already exist in the repo.

## Details
- Uses `pull_request_target` (with `edited` included) so PRs from forks are labeled correctly and re-labeled if the target branch changes.
- `sync-labels: true` so retargeting a PR (e.g. `v1-dev` → `main`) swaps `v1`/`v2` accordingly.
- Minimal permissions (`pull-requests: write`) and a Harden Runner step, matching existing workflow conventions.
- Third-party actions pinned to commit SHAs.

## Files
- `.github/labeler.yml` — label → base-branch rules
- `.github/workflows/target-branch-labeler.yml` — workflow

## Notes
The `release-*` branches are intentionally not covered here (they'd need dynamic label names, which `actions/labeler` can't produce). Happy to add a follow-up if desired.