### PR TITLE
chore: rename CRD group ratify.dev to ratify.sh

### DIFF
--- a/.github/workflows/e2e-k8s.yml
+++ b/.github/workflows/e2e-k8s.yml
@@ -88,7 +88,7 @@ jobs:
         if: ${{ always() }}
         run: |
           kubectl logs -n gatekeeper-system -l app.kubernetes.io/name=ratify-gatekeeper-provider --tail=-1 > logs-ratify-provider-${{ inputs.k8s_version }}-${{ inputs.gatekeeper_version }}-config-policy.json 2>&1 || true
-          kubectl get executors.config.ratify.dev -A -o yaml > logs-executor-${{ inputs.k8s_version }}-${{ inputs.gatekeeper_version }}.yaml 2>&1 || true
+          kubectl get executors.config.ratify.sh -A -o yaml > logs-executor-${{ inputs.k8s_version }}-${{ inputs.gatekeeper_version }}.yaml 2>&1 || true
       - name: Run e2e with Rego policy
         run: |
           make test-e2e

--- a/PROJECT
+++ b/PROJECT
@@ -3,7 +3,7 @@
 # and allow the plugins properly work.
 # More info: https://book.kubebuilder.io/reference/project-config.html
 cliVersion: 4.6.0
-domain: ratify.dev
+domain: ratify.sh
 layout:
 - go.kubebuilder.io/v4
 projectName: crd
@@ -13,7 +13,7 @@ resources:
     crdVersion: v1
     namespaced: true
   controller: true
-  domain: ratify.dev
+  domain: ratify.sh
   group: config
   kind: Executor
   path: github.com/notaryproject/ratify/v2/api/v2alpha1

--- a/api/v2alpha1/groupversion_info.go
+++ b/api/v2alpha1/groupversion_info.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package v2alpha1 contains API Schema definitions for the config v2alpha1 API group.
 // +kubebuilder:object:generate=true
-// +groupName=config.ratify.dev
+// +groupName=config.ratify.sh
 package v2alpha1
 
 import (
@@ -26,7 +26,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects.
-	GroupVersion = schema.GroupVersion{Group: "config.ratify.dev", Version: "v2alpha1"}
+	GroupVersion = schema.GroupVersion{Group: "config.ratify.sh", Version: "v2alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/config/crd/bases/config.ratify.sh_executors.yaml
+++ b/config/crd/bases/config.ratify.sh_executors.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-  name: executors.config.ratify.dev
+  name: executors.config.ratify.sh
 spec:
-  group: config.ratify.dev
+  group: config.ratify.sh
   names:
     kind: Executor
     listKind: ExecutorList

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,7 +2,7 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
-- bases/config.ratify.dev_executors.yaml
+- bases/config.ratify.sh_executors.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 patches:

--- a/config/rbac/executor_admin_role.yaml
+++ b/config/rbac/executor_admin_role.yaml
@@ -1,7 +1,7 @@
 # This rule is not used by the project crd itself.
 # It is provided to allow the cluster admin to help manage permissions for users.
 #
-# Grants full permissions ('*') over config.ratify.dev.
+# Grants full permissions ('*') over config.ratify.sh.
 # This role is intended for users authorized to modify roles and bindings within the cluster,
 # enabling them to delegate specific permissions to other users or groups as needed.
 
@@ -14,13 +14,13 @@ metadata:
   name: executor-admin-role
 rules:
 - apiGroups:
-  - config.ratify.dev
+  - config.ratify.sh
   resources:
   - executors
   verbs:
   - '*'
 - apiGroups:
-  - config.ratify.dev
+  - config.ratify.sh
   resources:
   - executors/status
   verbs:

--- a/config/rbac/executor_editor_role.yaml
+++ b/config/rbac/executor_editor_role.yaml
@@ -1,7 +1,7 @@
 # This rule is not used by the project crd itself.
 # It is provided to allow the cluster admin to help manage permissions for users.
 #
-# Grants permissions to create, update, and delete resources within the config.ratify.dev.
+# Grants permissions to create, update, and delete resources within the config.ratify.sh.
 # This role is intended for users who need to manage these resources
 # but should not control RBAC or manage permissions for others.
 
@@ -14,7 +14,7 @@ metadata:
   name: executor-editor-role
 rules:
 - apiGroups:
-  - config.ratify.dev
+  - config.ratify.sh
   resources:
   - executors
   verbs:
@@ -26,7 +26,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - config.ratify.dev
+  - config.ratify.sh
   resources:
   - executors/status
   verbs:

--- a/config/rbac/executor_viewer_role.yaml
+++ b/config/rbac/executor_viewer_role.yaml
@@ -1,7 +1,7 @@
 # This rule is not used by the project crd itself.
 # It is provided to allow the cluster admin to help manage permissions for users.
 #
-# Grants read-only access to config.ratify.dev resources.
+# Grants read-only access to config.ratify.sh resources.
 # This role is intended for users who need visibility into these resources
 # without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
 
@@ -14,7 +14,7 @@ metadata:
   name: executor-viewer-role
 rules:
 - apiGroups:
-  - config.ratify.dev
+  - config.ratify.sh
   resources:
   - executors
   verbs:
@@ -22,7 +22,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - config.ratify.dev
+  - config.ratify.sh
   resources:
   - executors/status
   verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -17,13 +17,13 @@ rules:
   - update
   - watch
 - apiGroups:
-  - config.ratify.dev
+  - config.ratify.sh
   resources:
   - executors/finalizers
   verbs:
   - update
 - apiGroups:
-  - config.ratify.dev
+  - config.ratify.sh
   resources:
   - executors/status
   verbs:

--- a/config/samples/config_v2alpha1_azure_executor.yaml
+++ b/config/samples/config_v2alpha1_azure_executor.yaml
@@ -1,4 +1,4 @@
-apiVersion: config.ratify.dev/v2alpha1
+apiVersion: config.ratify.sh/v2alpha1
 kind: Executor
 metadata:
   labels:

--- a/config/samples/config_v2alpha1_executor.yaml
+++ b/config/samples/config_v2alpha1_executor.yaml
@@ -1,4 +1,4 @@
-apiVersion: config.ratify.dev/v2alpha1
+apiVersion: config.ratify.sh/v2alpha1
 kind: Executor
 metadata:
   labels:

--- a/deployments/ratify-gatekeeper-provider/crds/executors.config.ratify.sh.yaml
+++ b/deployments/ratify-gatekeeper-provider/crds/executors.config.ratify.sh.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-  name: executors.config.ratify.dev
+  name: executors.config.ratify.sh
 spec:
-  group: config.ratify.dev
+  group: config.ratify.sh
   names:
     kind: Executor
     listKind: ExecutorList

--- a/deployments/ratify-gatekeeper-provider/templates/executor.yaml
+++ b/deployments/ratify-gatekeeper-provider/templates/executor.yaml
@@ -1,4 +1,4 @@
-apiVersion: config.ratify.dev/v2alpha1
+apiVersion: config.ratify.sh/v2alpha1
 kind: Executor
 metadata:
   name: {{ include "ratify.fullname" . }}-executor-1

--- a/deployments/ratify-gatekeeper-provider/templates/ratify-manager-role-clusterrole.yaml
+++ b/deployments/ratify-gatekeeper-provider/templates/ratify-manager-role-clusterrole.yaml
@@ -25,7 +25,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - config.ratify.dev
+  - config.ratify.sh
   resources:
   - executors
   verbs:
@@ -37,13 +37,13 @@ rules:
   - update
   - watch
 - apiGroups:
-  - config.ratify.dev
+  - config.ratify.sh
   resources:
   - executors/finalizers
   verbs:
   - update
 - apiGroups:
-  - config.ratify.dev
+  - config.ratify.sh
   resources:
   - executors/status
   verbs:

--- a/dev.helmfile.yaml.gotmpl
+++ b/dev.helmfile.yaml.gotmpl
@@ -67,7 +67,7 @@ releases:
         args:
           - "delete"
           - "crd"
-          - "executors.config.ratify.dev"
+          - "executors.config.ratify.sh"
           - "--ignore-not-found=true"
     set:
       - name: notation.certs[0].cert

--- a/internal/controller/executor_controller.go
+++ b/internal/controller/executor_controller.go
@@ -34,9 +34,9 @@ type ExecutorReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=config.ratify.dev,resources=executors,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=config.ratify.dev,resources=executors/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=config.ratify.dev,resources=executors/finalizers,verbs=update
+// +kubebuilder:rbac:groups=config.ratify.sh,resources=executors,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=config.ratify.sh,resources=executors/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=config.ratify.sh,resources=executors/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/test/bats/azure-test.bats
+++ b/test/bats/azure-test.bats
@@ -75,15 +75,15 @@ RATIFY_NAMESPACE=gatekeeper-system
     sleep 5
 
     # save the original executor so the AKV notation cert can be restored afterwards
-    run bash -c "kubectl get executors.config.ratify.dev/${EXECUTOR_NAME} -o yaml > original-executor-leaf.yaml"
+    run bash -c "kubectl get executors.config.ratify.sh/${EXECUTOR_NAME} -o yaml > original-executor-leaf.yaml"
     assert_success
 
     # patch the notation verifier to trust the leaf-test ROOT certificate (inline)
     run bash -c 'ROOT_CERT=$(cat ~/.config/notation/truststore/x509/ca/leaf-test/root.crt) && \
-        kubectl get executors.config.ratify.dev/'"${EXECUTOR_NAME}"' -o json | \
+        kubectl get executors.config.ratify.sh/'"${EXECUTOR_NAME}"' -o json | \
         jq --arg cert "$ROOT_CERT" '"'"'del(.metadata.managedFields, .metadata.resourceVersion, .metadata.uid, .metadata.creationTimestamp, .metadata.generation, .status) | .spec.verifiers = [(.spec.verifiers[] | if .name == "notation-1" then .parameters.certificates = [{"type": "ca", "inline": {"certs": $cert}}] else . end)]'"'"' | kubectl apply --server-side --force-conflicts -f -'
     assert_success
-    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get executors.config.ratify.dev/${EXECUTOR_NAME} -o jsonpath='{.status.succeeded}' | grep true"
+    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get executors.config.ratify.sh/${EXECUTOR_NAME} -o jsonpath='{.status.succeeded}' | grep true"
 
     # a leaf-signed image chains up to the root cert, so admission should pass
     run wait_for_process 20 10 'kubectl run demo-leaf --namespace default --image=${TEST_REGISTRY}/notation:leafSigned'
@@ -91,13 +91,13 @@ RATIFY_NAMESPACE=gatekeeper-system
 
     # patch the notation verifier to trust ONLY the LEAF certificate (inline); leaf certs are rejected as trust anchors
     run bash -c 'LEAF_CERT=$(cat ~/.config/notation/truststore/x509/ca/leaf-test/leaf.crt) && \
-        kubectl get executors.config.ratify.dev/'"${EXECUTOR_NAME}"' -o json | \
+        kubectl get executors.config.ratify.sh/'"${EXECUTOR_NAME}"' -o json | \
         jq --arg cert "$LEAF_CERT" '"'"'del(.metadata.managedFields, .metadata.resourceVersion, .metadata.uid, .metadata.creationTimestamp, .metadata.generation, .status) | .spec.verifiers = [(.spec.verifiers[] | if .name == "notation-1" then .parameters.certificates = [{"type": "ca", "inline": {"certs": $cert}}] else . end)]'"'"' | kubectl apply --server-side --force-conflicts -f -'
     assert_success
-    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get executors.config.ratify.dev/${EXECUTOR_NAME} -o jsonpath='{.status.succeeded}' | grep false"
+    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get executors.config.ratify.sh/${EXECUTOR_NAME} -o jsonpath='{.status.succeeded}' | grep false"
 
     # the executor status must explain why the leaf-only trust store was rejected
-    run bash -c "kubectl get executors.config.ratify.dev/${EXECUTOR_NAME} -o jsonpath='{.status.error}' | grep 'is not a CA certificate or self-signed signing certificate'"
+    run bash -c "kubectl get executors.config.ratify.sh/${EXECUTOR_NAME} -o jsonpath='{.status.error}' | grep 'is not a CA certificate or self-signed signing certificate'"
     assert_success
 
     # the provider keeps serving the last-known-good (root cert) config after an

--- a/test/bats/base-test.bats
+++ b/test/bats/base-test.bats
@@ -37,7 +37,7 @@ EXECUTOR_NAME=ratify-gatekeeper-provider-executor-1
     assert_success
     sleep 5
     # wait for executor to be reconciled by controller
-    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get executors.config.ratify.dev -n ${RATIFY_NAMESPACE} -o jsonpath='{.items[0].status.succeeded}' | grep true"
+    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get executors.config.ratify.sh -n ${RATIFY_NAMESPACE} -o jsonpath='{.items[0].status.succeeded}' | grep true"
     run kubectl run demo --namespace default --image=registry:5000/notation:signed
     assert_success
     run kubectl run demo1 --namespace default --image=registry:5000/notation:unsigned
@@ -164,7 +164,7 @@ EOF
     sleep 5
 
     # validate executor status shows success
-    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get executors.config.ratify.dev/${EXECUTOR_NAME} -n ${RATIFY_NAMESPACE} -o jsonpath='{.status.succeeded}' | grep true"
+    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get executors.config.ratify.sh/${EXECUTOR_NAME} -n ${RATIFY_NAMESPACE} -o jsonpath='{.status.succeeded}' | grep true"
     run kubectl run demo --namespace default --image=registry:5000/notation:signed
     assert_success
 
@@ -183,19 +183,19 @@ EOF
     }
 
     # save original executor state
-    run bash -c "kubectl get executors.config.ratify.dev/${EXECUTOR_NAME} -o yaml > original-executor-tsa.yaml"
+    run bash -c "kubectl get executors.config.ratify.sh/${EXECUTOR_NAME} -o yaml > original-executor-tsa.yaml"
     assert_success
 
     # validate executor status shows success
-    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get executors.config.ratify.dev/${EXECUTOR_NAME} -o jsonpath='{.status.succeeded}' | grep true"
+    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get executors.config.ratify.sh/${EXECUTOR_NAME} -o jsonpath='{.status.succeeded}' | grep true"
 
     # apply executor with TSA trust store certificate using JSON to avoid YAML document separator issues with PEM certs
     run bash -c 'TSA_CERT=$(cat ./test/bats/tests/certificates/tsarootca.cer) && \
-        kubectl get executors.config.ratify.dev/'"${EXECUTOR_NAME}"' -o json | \
+        kubectl get executors.config.ratify.sh/'"${EXECUTOR_NAME}"' -o json | \
         jq --arg tsa_cert "$TSA_CERT" '"'"'del(.metadata.managedFields, .metadata.resourceVersion, .metadata.uid, .metadata.creationTimestamp, .metadata.generation, .status) | .spec.verifiers = [(.spec.verifiers[] | if .name == "notation-1" then .parameters.certificates += [{"type": "tsa", "inline": {"certs": $tsa_cert}}] else . end)]'"'"' | kubectl apply --server-side --force-conflicts -f -'
     assert_success
     # wait for executor to be reconciled after patch
-    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get executors.config.ratify.dev/${EXECUTOR_NAME} -o jsonpath='{.status.succeeded}' | grep true"
+    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get executors.config.ratify.sh/${EXECUTOR_NAME} -o jsonpath='{.status.succeeded}' | grep true"
 
     # verify that the image can now be run
     run kubectl run demo-tsa --namespace default --image=registry:5000/notation:tsa
@@ -338,7 +338,7 @@ EOF
     }
 
     # save original executor state
-    run bash -c "kubectl get executors.config.ratify.dev/${EXECUTOR_NAME} -o yaml > original-executor-cosign-keyless.yaml"
+    run bash -c "kubectl get executors.config.ratify.sh/${EXECUTOR_NAME} -o yaml > original-executor-cosign-keyless.yaml"
     assert_success
 
     # apply keyless cosign executor
@@ -346,7 +346,7 @@ EOF
     assert_success
 
     # wait for executor to be reconciled after config change
-    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get executors.config.ratify.dev/${EXECUTOR_NAME} -o jsonpath='{.status.succeeded}' | grep true"
+    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get executors.config.ratify.sh/${EXECUTOR_NAME} -o jsonpath='{.status.succeeded}' | grep true"
 
     wait_for_process 20 10 'kubectl run cosign-demo-keyless --namespace default --image=wabbitnetworks.azurecr.io/test/cosign-image:signed-keyless'
 }
@@ -381,15 +381,15 @@ EOF
     }
 
     # save original executor state
-    run bash -c "kubectl get executors.config.ratify.dev/${EXECUTOR_NAME} -o yaml > original-executor-crd.yaml"
+    run bash -c "kubectl get executors.config.ratify.sh/${EXECUTOR_NAME} -o yaml > original-executor-crd.yaml"
     assert_success
 
     echo "Patch executor to remove notation verifier and validate deployment fails"
-    run bash -c 'kubectl get executors.config.ratify.dev/'"${EXECUTOR_NAME}"' -o json | \
+    run bash -c 'kubectl get executors.config.ratify.sh/'"${EXECUTOR_NAME}"' -o json | \
         jq '"'"'del(.metadata.managedFields, .metadata.resourceVersion, .metadata.uid, .metadata.creationTimestamp, .metadata.generation, .status) | .spec.verifiers = [.spec.verifiers[] | select(.name != "notation-1")] | .spec.policyEnforcer.parameters.policy.rules = [.spec.policyEnforcer.parameters.policy.rules[] | select(.verifierName != "notation-1")]'"'"' | kubectl apply --server-side --force-conflicts -f -'
     assert_success
     # wait for executor to be reconciled
-    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get executors.config.ratify.dev/${EXECUTOR_NAME} -o jsonpath='{.status.succeeded}' | grep true"
+    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get executors.config.ratify.sh/${EXECUTOR_NAME} -o jsonpath='{.status.succeeded}' | grep true"
     run kubectl run crdtest --namespace default --image=registry:5000/notation:signed
     assert_failure
 
@@ -397,7 +397,7 @@ EOF
     run restore_executor original-executor-crd.yaml
     assert_success
     # wait for executor to be reconciled
-    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get executors.config.ratify.dev/${EXECUTOR_NAME} -o jsonpath='{.status.succeeded}' | grep true"
+    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get executors.config.ratify.sh/${EXECUTOR_NAME} -o jsonpath='{.status.succeeded}' | grep true"
     run kubectl run crdtest --namespace default --image=registry:5000/notation:signed
     assert_success
 }
@@ -411,16 +411,16 @@ EOF
     }
 
     # save original executor state
-    run bash -c "kubectl get executors.config.ratify.dev/${EXECUTOR_NAME} -o yaml > original-executor-store.yaml"
+    run bash -c "kubectl get executors.config.ratify.sh/${EXECUTOR_NAME} -o yaml > original-executor-store.yaml"
     assert_success
 
     # patch executor with an invalid store type
-    run bash -c 'kubectl get executors.config.ratify.dev/'"${EXECUTOR_NAME}"' -o json | \
+    run bash -c 'kubectl get executors.config.ratify.sh/'"${EXECUTOR_NAME}"' -o json | \
         jq '"'"'del(.metadata.managedFields, .metadata.resourceVersion, .metadata.uid, .metadata.creationTimestamp, .metadata.generation, .status) | .spec.stores = [{"type": "invalid-store-type", "parameters": {"plainHttp": true}}]'"'"' | kubectl apply --server-side --force-conflicts -f -'
     assert_success
     # wait for executor to report error
     sleep 5
-    run bash -c "kubectl get executors.config.ratify.dev/${EXECUTOR_NAME} -o jsonpath='{.status.error}' | grep -i 'store'"
+    run bash -c "kubectl get executors.config.ratify.sh/${EXECUTOR_NAME} -o jsonpath='{.status.error}' | grep -i 'store'"
     assert_success
 }
 
@@ -479,7 +479,7 @@ EOF
     }
 
     # save original executor state
-    run bash -c "kubectl get executors.config.ratify.dev/${EXECUTOR_NAME} -o yaml > original-executor-certstore.yaml"
+    run bash -c "kubectl get executors.config.ratify.sh/${EXECUTOR_NAME} -o yaml > original-executor-certstore.yaml"
     assert_success
 
     run kubectl apply -f ./library/multi-tenancy-validation/template.yaml
@@ -495,11 +495,11 @@ EOF
 
     # patch executor to use alternate inline certificate
     run bash -c 'ALT_CERT=$(cat ~/.config/notation/truststore/x509/ca/alternate-cert/alternate-cert.crt) && \
-        kubectl get executors.config.ratify.dev/'"${EXECUTOR_NAME}"' -o json | \
+        kubectl get executors.config.ratify.sh/'"${EXECUTOR_NAME}"' -o json | \
         jq --arg alt_cert "$ALT_CERT" '"'"'del(.metadata.managedFields, .metadata.resourceVersion, .metadata.uid, .metadata.creationTimestamp, .metadata.generation, .status) | .spec.verifiers = [(.spec.verifiers[] | if .name == "notation-1" then .parameters.certificates = [{"type": "ca", "inline": {"certs": $alt_cert}}] else . end)]'"'"' | kubectl apply --server-side --force-conflicts -f -'
     assert_success
     # wait for executor to be reconciled
-    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get executors.config.ratify.dev/${EXECUTOR_NAME} -o jsonpath='{.status.succeeded}' | grep true"
+    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get executors.config.ratify.sh/${EXECUTOR_NAME} -o jsonpath='{.status.succeeded}' | grep true"
     sleep 10
 
     # verify that the image can now be run
@@ -517,7 +517,7 @@ EOF
     }
 
     # save original executor state
-    run bash -c "kubectl get executors.config.ratify.dev/${EXECUTOR_NAME} -o yaml > original-executor-kmp.yaml"
+    run bash -c "kubectl get executors.config.ratify.sh/${EXECUTOR_NAME} -o yaml > original-executor-kmp.yaml"
     assert_success
 
     run kubectl apply -f ./library/multi-tenancy-validation/template.yaml
@@ -533,11 +533,11 @@ EOF
 
     # patch executor to use alternate inline certificate
     run bash -c 'ALT_CERT=$(cat ~/.config/notation/truststore/x509/ca/alternate-cert/alternate-cert.crt) && \
-        kubectl get executors.config.ratify.dev/'"${EXECUTOR_NAME}"' -o json | \
+        kubectl get executors.config.ratify.sh/'"${EXECUTOR_NAME}"' -o json | \
         jq --arg alt_cert "$ALT_CERT" '"'"'del(.metadata.managedFields, .metadata.resourceVersion, .metadata.uid, .metadata.creationTimestamp, .metadata.generation, .status) | .spec.verifiers = [(.spec.verifiers[] | if .name == "notation-1" then .parameters.certificates = [{"type": "ca", "inline": {"certs": $alt_cert}}] else . end)]'"'"' | kubectl apply --server-side --force-conflicts -f -'
     assert_success
     # wait for executor to be reconciled
-    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get executors.config.ratify.dev/${EXECUTOR_NAME} -o jsonpath='{.status.succeeded}' | grep true"
+    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get executors.config.ratify.sh/${EXECUTOR_NAME} -o jsonpath='{.status.succeeded}' | grep true"
 
     # verify that the image can now be run
     run kubectl run demo-alternate --namespace default --image=registry:5000/notation:signed-alternate
@@ -557,7 +557,7 @@ EOF
     }
 
     # save original executor state
-    run bash -c "kubectl get executors.config.ratify.dev/${EXECUTOR_NAME} -o yaml > original-executor-kmp-certstore.yaml"
+    run bash -c "kubectl get executors.config.ratify.sh/${EXECUTOR_NAME} -o yaml > original-executor-kmp-certstore.yaml"
     assert_success
 
     run kubectl apply -f ./library/multi-tenancy-validation/template.yaml
@@ -566,14 +566,14 @@ EOF
     assert_success
 
     # validate executor status shows success
-    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get executors.config.ratify.dev/${EXECUTOR_NAME} -o jsonpath='{.status.succeeded}' | grep true"
+    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get executors.config.ratify.sh/${EXECUTOR_NAME} -o jsonpath='{.status.succeeded}' | grep true"
     run kubectl run demo --namespace default --image=registry:5000/notation:signed
     assert_success
 
     sleep 10
 
     # validate executor still reports success
-    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get executors.config.ratify.dev/${EXECUTOR_NAME} -o jsonpath='{.status.succeeded}' | grep true"
+    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get executors.config.ratify.sh/${EXECUTOR_NAME} -o jsonpath='{.status.succeeded}' | grep true"
     run kubectl run demo1 --namespace default --image=registry:5000/notation:signed
     assert_success
 }
@@ -614,7 +614,7 @@ EOF
     }
 
     # save original executor state
-    run bash -c "kubectl get executors.config.ratify.dev/${EXECUTOR_NAME} -o yaml > original-executor-leaf.yaml"
+    run bash -c "kubectl get executors.config.ratify.sh/${EXECUTOR_NAME} -o yaml > original-executor-leaf.yaml"
     assert_success
 
     run kubectl apply -f ./library/multi-tenancy-validation/template.yaml
@@ -624,10 +624,10 @@ EOF
 
     # patch executor to use root cert for leaf-test
     run bash -c 'ROOT_CERT=$(cat ~/.config/notation/truststore/x509/ca/leaf-test/root.crt) && \
-        kubectl get executors.config.ratify.dev/'"${EXECUTOR_NAME}"' -o json | \
+        kubectl get executors.config.ratify.sh/'"${EXECUTOR_NAME}"' -o json | \
         jq --arg root_cert "$ROOT_CERT" '"'"'del(.metadata.managedFields, .metadata.resourceVersion, .metadata.uid, .metadata.creationTimestamp, .metadata.generation, .status) | .spec.verifiers = [(.spec.verifiers[] | if .name == "notation-1" then .parameters.certificates = [{"type": "ca", "inline": {"certs": $root_cert}}] else . end)]'"'"' | kubectl apply --server-side --force-conflicts -f -'
     assert_success
-    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get executors.config.ratify.dev/${EXECUTOR_NAME} -o jsonpath='{.status.succeeded}' | grep true"
+    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get executors.config.ratify.sh/${EXECUTOR_NAME} -o jsonpath='{.status.succeeded}' | grep true"
 
     # verify that the image can be run with a root cert
     run kubectl run demo-leaf --namespace default --image=registry:5000/notation:leafSigned
@@ -635,10 +635,10 @@ EOF
 
     # patch executor to use the leaf cert instead of the root cert; leaf certs are rejected as trust anchors
     run bash -c 'LEAF_CERT=$(cat ~/.config/notation/truststore/x509/ca/leaf-test/leaf.crt) && \
-        kubectl get executors.config.ratify.dev/'"${EXECUTOR_NAME}"' -o json | \
+        kubectl get executors.config.ratify.sh/'"${EXECUTOR_NAME}"' -o json | \
         jq --arg leaf_cert "$LEAF_CERT" '"'"'del(.metadata.managedFields, .metadata.resourceVersion, .metadata.uid, .metadata.creationTimestamp, .metadata.generation, .status) | .spec.verifiers = [(.spec.verifiers[] | if .name == "notation-1" then .parameters.certificates = [{"type": "ca", "inline": {"certs": $leaf_cert}}] else . end)]'"'"' | kubectl apply --server-side --force-conflicts -f -'
     assert_success
-    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get executors.config.ratify.dev/${EXECUTOR_NAME} -o jsonpath='{.status.succeeded}' | grep false"
+    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get executors.config.ratify.sh/${EXECUTOR_NAME} -o jsonpath='{.status.succeeded}' | grep false"
 
     # the provider keeps serving the last-known-good (root cert) config after an
     # invalid update, so restart it to force a fresh load of the leaf-only trust

--- a/test/bats/tests/config/executor_cosign_akv.yaml
+++ b/test/bats/tests/config/executor_cosign_akv.yaml
@@ -1,4 +1,4 @@
-apiVersion: config.ratify.dev/v2alpha1
+apiVersion: config.ratify.sh/v2alpha1
 kind: Executor
 metadata:
   name: ratify-gatekeeper-provider-executor-1

--- a/test/bats/tests/config/executor_cosign_keyless.yaml
+++ b/test/bats/tests/config/executor_cosign_keyless.yaml
@@ -1,4 +1,4 @@
-apiVersion: config.ratify.dev/v2alpha1
+apiVersion: config.ratify.sh/v2alpha1
 kind: Executor
 metadata:
   name: ratify-gatekeeper-provider-executor-1

--- a/test/bats/tests/config/executor_cosign_legacy.yaml
+++ b/test/bats/tests/config/executor_cosign_legacy.yaml
@@ -1,4 +1,4 @@
-apiVersion: config.ratify.dev/v2alpha1
+apiVersion: config.ratify.sh/v2alpha1
 kind: Executor
 metadata:
   name: ratify-gatekeeper-provider-executor-1

--- a/test/bats/tests/config/executor_cosign_legacy_keyless.yaml
+++ b/test/bats/tests/config/executor_cosign_legacy_keyless.yaml
@@ -1,4 +1,4 @@
-apiVersion: config.ratify.dev/v2alpha1
+apiVersion: config.ratify.sh/v2alpha1
 kind: Executor
 metadata:
   name: ratify-gatekeeper-provider-executor-1

--- a/test/bats/tests/config/executor_invalid_store.yaml
+++ b/test/bats/tests/config/executor_invalid_store.yaml
@@ -1,4 +1,4 @@
-apiVersion: config.ratify.dev/v2alpha1
+apiVersion: config.ratify.sh/v2alpha1
 kind: Executor
 metadata:
   name: ratify-gatekeeper-provider-executor-1

--- a/test/bats/tests/config/executor_k8s_secret_auth.yaml
+++ b/test/bats/tests/config/executor_k8s_secret_auth.yaml
@@ -1,4 +1,4 @@
-apiVersion: config.ratify.dev/v2alpha1
+apiVersion: config.ratify.sh/v2alpha1
 kind: Executor
 metadata:
   name: ratify-gatekeeper-provider-executor-1

--- a/test/bats/tests/config/executor_namespace_cosign.yaml
+++ b/test/bats/tests/config/executor_namespace_cosign.yaml
@@ -1,4 +1,4 @@
-apiVersion: config.ratify.dev/v2alpha1
+apiVersion: config.ratify.sh/v2alpha1
 kind: Executor
 metadata:
   name: executor-cosign-default

--- a/test/bats/tests/config/executor_namespace_notation.yaml
+++ b/test/bats/tests/config/executor_namespace_notation.yaml
@@ -1,4 +1,4 @@
-apiVersion: config.ratify.dev/v2alpha1
+apiVersion: config.ratify.sh/v2alpha1
 kind: Executor
 metadata:
   name: executor-notation-default

--- a/test/bats/tests/config/executor_no_notation.yaml
+++ b/test/bats/tests/config/executor_no_notation.yaml
@@ -1,4 +1,4 @@
-apiVersion: config.ratify.dev/v2alpha1
+apiVersion: config.ratify.sh/v2alpha1
 kind: Executor
 metadata:
   name: ratify-gatekeeper-provider-executor-1

--- a/test/bats/tests/config/executor_no_verifiers.yaml
+++ b/test/bats/tests/config/executor_no_verifiers.yaml
@@ -1,4 +1,4 @@
-apiVersion: config.ratify.dev/v2alpha1
+apiVersion: config.ratify.sh/v2alpha1
 kind: Executor
 metadata:
   name: ratify-gatekeeper-provider-executor-1

--- a/test/bats/tests/config/executor_notation_akv.yaml
+++ b/test/bats/tests/config/executor_notation_akv.yaml
@@ -1,4 +1,4 @@
-apiVersion: config.ratify.dev/v2alpha1
+apiVersion: config.ratify.sh/v2alpha1
 kind: Executor
 metadata:
   name: ratify-gatekeeper-provider-executor-1


### PR DESCRIPTION
## Summary
- Migrate all references of `ratify.dev` domain to `ratify.sh` across the entire repository
- Rename CRD YAML files: `config.ratify.dev_executors.yaml` → `config.ratify.sh_executors.yaml`, `executors.config.ratify.dev.yaml` → `executors.config.ratify.sh.yaml`
- Update Go source code, RBAC roles, Helm templates, test configs, and documentation

