### PR TITLE
fix(controller): stop Executor status feedback loop and retry on conflict

### DIFF
--- a/internal/controller/executor_controller.go
+++ b/internal/controller/executor_controller.go
@@ -21,9 +21,13 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	configv2alpha1 "github.com/notaryproject/ratify/v2/api/v2alpha1"
 )
@@ -75,22 +79,46 @@ func (r *ExecutorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 }
 
 // SetupWithManager sets up the controller with the Manager.
+//
+// The watch is filtered with GenerationChangedPredicate so that status-only
+// updates (which do not bump metadata.generation) do not re-trigger Reconcile.
+// Without this predicate every status write produced by updateStatus would
+// itself be an update event that re-enqueues the object, creating a feedback
+// loop that repeatedly rebuilds the in-memory executor (and hammers external
+// providers such as Azure Key Vault). The loop is amplified once the
+// deployment is scaled to multiple replicas.
 func (r *ExecutorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&configv2alpha1.Executor{}).
+		For(&configv2alpha1.Executor{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Complete(r)
 }
 
-func (r *ExecutorReconciler) updateStatus(ctx context.Context, executor *configv2alpha1.Executor, err error) {
-	if err != nil {
-		executor.Status.Succeeded = false
-		executor.Status.Error = err.Error()
-	} else {
-		executor.Status.Succeeded = true
-		executor.Status.Error = ""
-	}
-	if statusErr := r.Status().Update(ctx, executor); statusErr != nil {
-		log := logf.FromContext(ctx)
-		log.Error(statusErr, "Failed to update Executor status", "executor", executor.Name)
+// updateStatus records the outcome of the reconcile on the Executor's status
+// subresource.
+//
+// The write is wrapped in retry.RetryOnConflict so that concurrent writers
+// (e.g. multiple replicas, or an informer resync racing a spec change) do not
+// silently drop the update on an HTTP 409. On conflict the object is re-fetched
+// to obtain the latest resourceVersion before the status is re-applied.
+func (r *ExecutorReconciler) updateStatus(ctx context.Context, executor *configv2alpha1.Executor, upsertErr error) {
+	log := logf.FromContext(ctx)
+	key := types.NamespacedName{Namespace: executor.Namespace, Name: executor.Name}
+
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var latest configv2alpha1.Executor
+		if getErr := r.Get(ctx, key, &latest); getErr != nil {
+			return getErr
+		}
+		if upsertErr != nil {
+			latest.Status.Succeeded = false
+			latest.Status.Error = upsertErr.Error()
+		} else {
+			latest.Status.Succeeded = true
+			latest.Status.Error = ""
+		}
+		return r.Status().Update(ctx, &latest)
+	})
+	if retryErr != nil {
+		log.Error(retryErr, "Failed to update Executor status", "executor", executor.Name)
 	}
 }

--- a/internal/controller/executor_controller_retry_test.go
+++ b/internal/controller/executor_controller_retry_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright The Ratify Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	configv2alpha1 "github.com/notaryproject/ratify/v2/api/v2alpha1"
+)
+
+func newTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := configv2alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add scheme: %v", err)
+	}
+	return scheme
+}
+
+// TestUpdateStatusRetriesOnConflict verifies that updateStatus does not silently
+// drop the status write when the first Status().Update returns an HTTP 409
+// conflict, but instead re-fetches and retries until it succeeds.
+func TestUpdateStatusRetriesOnConflict(t *testing.T) {
+	scheme := newTestScheme(t)
+	executor := &configv2alpha1.Executor{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+	}
+
+	var updateAttempts int
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(executor).
+		WithStatusSubresource(executor).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(ctx context.Context, cl client.Client, subResourceName string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+				updateAttempts++
+				if updateAttempts == 1 {
+					// Simulate another writer winning the optimistic-concurrency
+					// race on the first attempt.
+					return apierrors.NewConflict(
+						schema.GroupResource{Group: "config.ratify.dev", Resource: "executors"},
+						obj.GetName(),
+						errors.New("the object has been modified"),
+					)
+				}
+				return cl.Status().Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	r := &ExecutorReconciler{Client: c, Scheme: scheme}
+	r.updateStatus(context.Background(), executor, nil)
+
+	if updateAttempts < 2 {
+		t.Fatalf("expected updateStatus to retry after a conflict, got %d attempt(s)", updateAttempts)
+	}
+
+	var got configv2alpha1.Executor
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &got); err != nil {
+		t.Fatalf("failed to get executor: %v", err)
+	}
+	if !got.Status.Succeeded {
+		t.Errorf("expected Status.Succeeded to be true after retry, got false")
+	}
+	if got.Status.Error != "" {
+		t.Errorf("expected empty Status.Error, got %q", got.Status.Error)
+	}
+}
+
+// TestUpdateStatusRecordsError verifies that a non-nil upsert error is persisted
+// to the Executor status.
+func TestUpdateStatusRecordsError(t *testing.T) {
+	scheme := newTestScheme(t)
+	executor := &configv2alpha1.Executor{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(executor).
+		WithStatusSubresource(executor).
+		Build()
+
+	r := &ExecutorReconciler{Client: c, Scheme: scheme}
+	r.updateStatus(context.Background(), executor, errors.New("boom"))
+
+	var got configv2alpha1.Executor
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &got); err != nil {
+		t.Fatalf("failed to get executor: %v", err)
+	}
+	if got.Status.Succeeded {
+		t.Errorf("expected Status.Succeeded to be false")
+	}
+	if got.Status.Error != "boom" {
+		t.Errorf("expected Status.Error to be %q, got %q", "boom", got.Status.Error)
+	}
+}


### PR DESCRIPTION
## Description

Fixes part of #2797.

When the provider deployment is scaled beyond `replicas: 1`, every pod runs its own `ExecutorReconciler` and they all write the same `Executor.status` concurrently. This PR lands the two **minimal / immediate** remediations from the issue:

1. **Cut the status feedback loop.** Add `builder.WithPredicates(predicate.GenerationChangedPredicate{})` to the `For(&Executor{})` watch. Status-only writes don't bump `metadata.generation`, so they no longer re-trigger `Reconcile`. This stops the reconcile→status-write→reconcile loop that repeatedly rebuilds the in-memory executor and hammers external providers (e.g. Azure Key Vault) — an effect amplified ×N across replicas.
2. **Stop swallowing write conflicts.** Wrap the status write in `retry.RetryOnConflict`, re-fetching the object to pick up the latest `resourceVersion` before re-applying status. Previously an HTTP 409 was only logged, so the losing writer's update was silently dropped.

Added unit tests (fake client + interceptor) covering the retry-on-conflict path and the error-recording path.

## Intentionally out of scope

Remediations 3–5 in the issue (leader election, per-pod `readiness`/metrics, Gatekeeper-style `ExecutorPodStatus`) are **not** included. Naively enabling leader election on the manager would prevent non-leader pods from running the reconciler — but the data plane serves verify requests from `GlobalExecutorManager` (populated by the reconciler) on **every** pod, so non-leaders would stop building their in-memory executor. That requires the larger control-plane/data-plane split discussed in the issue and is best done as a follow-up.

## Testing

- `go build ./...` ✅
- `go vet ./internal/controller/...` ✅
- `go test ./internal/controller/ -run TestUpdateStatus` ✅ (new unit tests)

_Note: the full ginkgo envtest suite was not run in my environment due to an unrelated local `/etc/hosts` misconfiguration; the existing specs compile and are unaffected by these changes._

Signed-off-by: Copilot