### PR TITLE
fix(controller): warn and roll back when invalid Executor config retains stale executor

### DIFF
--- a/internal/controller/executormanager.go
+++ b/internal/controller/executormanager.go
@@ -35,10 +35,8 @@ type executorManager struct {
 	mutex sync.Mutex
 	opts  map[string]e.ScopedOptions
 	// generations records the last successfully applied metadata.generation
-	// for each Executor resource. It is used to tell a genuine desired-state
-	// change (spec was edited) apart from a re-reconcile of an unchanged spec
-	// (e.g. periodic resync) so that only the former is treated as an
-	// enforcement gap when the build fails.
+	// per resource, used to tell a real spec change apart from a re-reconcile
+	// of an unchanged spec.
 	generations map[string]int64
 	executor    atomic.Pointer[e.ScopedExecutor]
 }

--- a/internal/controller/executormanager.go
+++ b/internal/controller/executormanager.go
@@ -34,9 +34,7 @@ import (
 type executorManager struct {
 	mutex sync.Mutex
 	opts  map[string]e.ScopedOptions
-	// generations records the last successfully applied metadata.generation
-	// per resource, used to tell a real spec change apart from a re-reconcile
-	// of an unchanged spec.
+	// generations records the last successfully applied generation per resource.
 	generations map[string]int64
 	executor    atomic.Pointer[e.ScopedExecutor]
 }

--- a/internal/controller/executormanager.go
+++ b/internal/controller/executormanager.go
@@ -77,31 +77,31 @@ func (m *executorManager) upsertExecutor(namespace, name string, opts *configv2a
 	m.opts[key] = scopedOpts
 
 	if err := m.refreshExecutor(); err != nil {
-		// Roll back the desired-state map so that a single broken config does
-		// not pollute m.opts and block subsequent reconciles of other
-		// (valid, unrelated) Executor resources.
+		specChanged := !genTracked || prevGen != newGen
+		if specChanged {
+			// The operator changed the spec and the new config is invalid.
+			// Force the update: converge to the (broken) desired state and
+			// fail closed so the data plane rejects new requests until the
+			// config is fixed. Keep the new opts so we stay converged and do
+			// NOT record the generation (it was never successfully applied).
+			//
+			// NOTE: a single shared ScopedExecutor backs all CRDs, so this
+			// fails closed the whole data plane, not just the changed scope.
+			m.executor.Store(nil)
+			logf.Log.Error(err, "Executor configuration changed but failed to build; failing closed. New requests will be REJECTED until the invalid config is corrected", "executor", key, "generation", newGen)
+			return err
+		}
+
+		// Unchanged spec: the failure is most likely transient (e.g. a
+		// dependency such as Azure Key Vault was briefly unreachable). Retain
+		// the last-known-good executor and roll back the desired-state map so
+		// it stays consistent with what is being served.
 		if existed {
 			m.opts[key] = prevOpts
 		} else {
 			delete(m.opts, key)
 		}
-
-		// If a previously built executor is still being served, the data plane
-		// keeps enforcing the last-known-good config. Warn loudly only when the
-		// spec actually changed (metadata.generation advanced): that is an
-		// operator edit that is silently NOT enforced until the config is fixed
-		// or the provider is restarted. An unchanged generation means a
-		// transient failure (e.g. a dependency such as Azure Key Vault was
-		// briefly unreachable) on a re-reconcile of the same spec, where
-		// retaining the cached executor is the intended graceful degradation.
-		if m.executor.Load() != nil {
-			specChanged := !genTracked || prevGen != newGen
-			if specChanged {
-				logf.Log.Error(err, "Executor configuration changed but failed to build; retaining the last-known-good executor. The updated configuration is NOT enforced on the data plane until the invalid config is corrected or the provider is restarted", "executor", key, "generation", newGen)
-			} else {
-				logf.Log.Info("Failed to rebuild Executor from an unchanged configuration (likely a transient error); retaining the last-known-good executor", "executor", key, "generation", newGen)
-			}
-		}
+		logf.Log.Info("Failed to rebuild Executor from an unchanged configuration (likely a transient error); retaining the last-known-good executor", "executor", key, "generation", newGen)
 		return err
 	}
 

--- a/internal/controller/executormanager.go
+++ b/internal/controller/executormanager.go
@@ -26,14 +26,21 @@ import (
 	"github.com/notaryproject/ratify/v2/internal/policyenforcer"
 	"github.com/notaryproject/ratify/v2/internal/store"
 	"github.com/notaryproject/ratify/v2/internal/verifier"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // executorManager manages the lifecycle of executor instances across different
 // namespaces and names.
 type executorManager struct {
-	mutex    sync.Mutex
-	opts     map[string]e.ScopedOptions
-	executor atomic.Pointer[e.ScopedExecutor]
+	mutex sync.Mutex
+	opts  map[string]e.ScopedOptions
+	// generations records the last successfully applied metadata.generation
+	// for each Executor resource. It is used to tell a genuine desired-state
+	// change (spec was edited) apart from a re-reconcile of an unchanged spec
+	// (e.g. periodic resync) so that only the former is treated as an
+	// enforcement gap when the build fails.
+	generations map[string]int64
+	executor    atomic.Pointer[e.ScopedExecutor]
 }
 
 // GlobalExecutorManager is an instance of executorManager that is used by
@@ -42,7 +49,8 @@ var GlobalExecutorManager executorManager
 
 func init() {
 	GlobalExecutorManager = executorManager{
-		opts: make(map[string]e.ScopedOptions),
+		opts:        make(map[string]e.ScopedOptions),
+		generations: make(map[string]int64),
 	}
 }
 
@@ -67,9 +75,45 @@ func (m *executorManager) upsertExecutor(namespace, name string, opts *configv2a
 	}
 
 	key := createOptsKey(namespace, name)
+	prevOpts, existed := m.opts[key]
+	prevGen, genTracked := m.generations[key]
+	newGen := opts.GetGeneration()
 	m.opts[key] = scopedOpts
 
-	return m.refreshExecutor()
+	if err := m.refreshExecutor(); err != nil {
+		// Roll back the desired-state map so that a single broken config does
+		// not pollute m.opts and block subsequent reconciles of other
+		// (valid, unrelated) Executor resources.
+		if existed {
+			m.opts[key] = prevOpts
+		} else {
+			delete(m.opts, key)
+		}
+
+		// If a previously built executor is still being served, the data plane
+		// keeps enforcing the last-known-good config. Warn loudly only when the
+		// spec actually changed (metadata.generation advanced): that is an
+		// operator edit that is silently NOT enforced until the config is fixed
+		// or the provider is restarted. An unchanged generation means a
+		// transient failure (e.g. a dependency such as Azure Key Vault was
+		// briefly unreachable) on a re-reconcile of the same spec, where
+		// retaining the cached executor is the intended graceful degradation.
+		if m.executor.Load() != nil {
+			specChanged := !genTracked || prevGen != newGen
+			if specChanged {
+				logf.Log.Error(err, "Executor configuration changed but failed to build; retaining the last-known-good executor. The updated configuration is NOT enforced on the data plane until the invalid config is corrected or the provider is restarted", "executor", key, "generation", newGen)
+			} else {
+				logf.Log.Info("Failed to rebuild Executor from an unchanged configuration (likely a transient error); retaining the last-known-good executor", "executor", key, "generation", newGen)
+			}
+		}
+		return err
+	}
+
+	if m.generations == nil {
+		m.generations = make(map[string]int64)
+	}
+	m.generations[key] = newGen
+	return nil
 }
 
 // deleteExecutor removes an executor instance under the given namespace and
@@ -81,6 +125,7 @@ func (m *executorManager) deleteExecutor(namespace, name string) error {
 	key := createOptsKey(namespace, name)
 	if _, exists := m.opts[key]; exists {
 		delete(m.opts, key)
+		delete(m.generations, key)
 		return m.refreshExecutor()
 	}
 	return fmt.Errorf("executor resource: %s/%s is not found", namespace, name)

--- a/internal/controller/executormanager_test.go
+++ b/internal/controller/executormanager_test.go
@@ -209,3 +209,94 @@ func TestDeleteExecutor_RemoveExistingEntry(t *testing.T) {
 		t.Fatalf("expected non-nil executor after deletion")
 	}
 }
+
+// newInvalidExecutor returns an Executor whose spec passes convertOptions
+// validation but fails NewScopedExecutor (the verifier type is not registered),
+// so the failure surfaces in refreshExecutor rather than convertOptions.
+func newInvalidExecutor() *configv2alpha1.Executor {
+	exec := newValidExecutor()
+	exec.Spec.Verifiers = []*configv2alpha1.VerifierOptions{
+		{
+			Name: "broken",
+			Type: "type-not-registered",
+		},
+	}
+	return exec
+}
+
+// TestUpsertExecutor_StaleRetainedAndNoOptsPollutionOnInvalidUpdate verifies
+// that when a previously succeeded Executor is updated to an invalid config:
+//   - the last-known-good executor is retained (graceful degradation),
+//   - the desired-state map (m.opts) is rolled back so the broken entry does
+//     not pollute it, and
+//   - subsequent updates to other (valid, unrelated) Executors still succeed.
+func TestUpsertExecutor_StaleRetainedAndNoOptsPollutionOnInvalidUpdate(t *testing.T) {
+	mgr := executorManager{
+		opts:        map[string]e.ScopedOptions{},
+		generations: map[string]int64{},
+	}
+
+	initial := newValidExecutor()
+	initial.Generation = 1
+	if err := mgr.upsertExecutor("default", "exec1", initial); err != nil {
+		t.Fatalf("initial upsert failed: %v", err)
+	}
+	goodExecutor := mgr.GetExecutor()
+	if goodExecutor == nil {
+		t.Fatalf("expected non-nil executor after initial upsert")
+	}
+	if got := mgr.opts[createOptsKey("default", "exec1")].Scopes[0]; got != "example.com" {
+		t.Fatalf("expected stored scope example.com, got %q", got)
+	}
+
+	// Update exec1 to an invalid config (generation advanced).
+	broken := newInvalidExecutor()
+	broken.Generation = 2
+	if err := mgr.upsertExecutor("default", "exec1", broken); err == nil {
+		t.Fatalf("expected error when updating to an invalid config")
+	}
+
+	// Last-known-good executor must be retained.
+	if mgr.GetExecutor() != goodExecutor {
+		t.Fatalf("expected the last-known-good executor to be retained after a failed update")
+	}
+
+	// m.opts must be rolled back to the previous valid config (no pollution).
+	if got := mgr.opts[createOptsKey("default", "exec1")].Scopes[0]; got != "example.com" {
+		t.Fatalf("expected opts to be rolled back to example.com, got %q", got)
+	}
+	// The last applied generation must remain the previous (successful) one.
+	if got := mgr.generations[createOptsKey("default", "exec1")]; got != 1 {
+		t.Fatalf("expected tracked generation to remain 1, got %d", got)
+	}
+
+	// A different, valid Executor must still be applicable (the broken CRD did
+	// not get stuck in m.opts and block unrelated reconciles).
+	other := newValidExecutor()
+	other.Spec.Scopes = []string{"other.com"}
+	other.Generation = 1
+	if err := mgr.upsertExecutor("default", "exec2", other); err != nil {
+		t.Fatalf("expected unrelated valid upsert to succeed, got: %v", err)
+	}
+}
+
+// TestUpsertExecutor_InvalidColdStartNoExecutor verifies that when the very
+// first (cold-start) config is invalid, no executor is served (fail-closed).
+func TestUpsertExecutor_InvalidColdStartNoExecutor(t *testing.T) {
+	mgr := executorManager{
+		opts:        map[string]e.ScopedOptions{},
+		generations: map[string]int64{},
+	}
+
+	broken := newInvalidExecutor()
+	broken.Generation = 1
+	if err := mgr.upsertExecutor("default", "exec1", broken); err == nil {
+		t.Fatalf("expected error on invalid cold-start config")
+	}
+	if mgr.GetExecutor() != nil {
+		t.Fatalf("expected no executor to be served on invalid cold start (fail-closed)")
+	}
+	if _, exists := mgr.opts[createOptsKey("default", "exec1")]; exists {
+		t.Fatalf("expected broken cold-start entry not to remain in opts")
+	}
+}

--- a/internal/controller/executormanager_test.go
+++ b/internal/controller/executormanager_test.go
@@ -224,13 +224,51 @@ func newInvalidExecutor() *configv2alpha1.Executor {
 	return exec
 }
 
-// TestUpsertExecutor_StaleRetainedAndNoOptsPollutionOnInvalidUpdate verifies
-// that when a previously succeeded Executor is updated to an invalid config:
-//   - the last-known-good executor is retained (graceful degradation),
-//   - the desired-state map (m.opts) is rolled back so the broken entry does
-//     not pollute it, and
-//   - subsequent updates to other (valid, unrelated) Executors still succeed.
-func TestUpsertExecutor_StaleRetainedAndNoOptsPollutionOnInvalidUpdate(t *testing.T) {
+// TestUpsertExecutor_FailClosedOnInvalidSpecChange verifies that when a
+// previously succeeded Executor has its spec changed (generation advanced) to
+// an invalid config, the manager forces the update: it converges to the new
+// (broken) desired state and fails closed so the data plane rejects requests.
+func TestUpsertExecutor_FailClosedOnInvalidSpecChange(t *testing.T) {
+	mgr := executorManager{
+		opts:        map[string]e.ScopedOptions{},
+		generations: map[string]int64{},
+	}
+
+	initial := newValidExecutor()
+	initial.Generation = 1
+	if err := mgr.upsertExecutor("default", "exec1", initial); err != nil {
+		t.Fatalf("initial upsert failed: %v", err)
+	}
+	if mgr.GetExecutor() == nil {
+		t.Fatalf("expected non-nil executor after initial upsert")
+	}
+
+	// Change exec1 to an invalid config (generation advanced).
+	broken := newInvalidExecutor()
+	broken.Generation = 2
+	if err := mgr.upsertExecutor("default", "exec1", broken); err == nil {
+		t.Fatalf("expected error when changing to an invalid config")
+	}
+
+	// Fail closed: no executor is served, so new requests are rejected.
+	if mgr.GetExecutor() != nil {
+		t.Fatalf("expected executor to be nil (fail-closed) after an invalid spec change")
+	}
+	// The desired state converged to the new (broken) config.
+	if got := mgr.opts[createOptsKey("default", "exec1")].Verifiers[0].Type; got != "type-not-registered" {
+		t.Fatalf("expected opts to converge to the new config, got verifier type %q", got)
+	}
+	// The generation is not recorded because it was never successfully applied.
+	if got := mgr.generations[createOptsKey("default", "exec1")]; got != 1 {
+		t.Fatalf("expected tracked generation to remain 1 (last success), got %d", got)
+	}
+}
+
+// TestUpsertExecutor_TransientRetainsLastKnownGood verifies that when a build
+// fails without any spec change (same generation, i.e. a re-reconcile of an
+// unchanged spec such as a periodic resync), the last-known-good executor is
+// retained and the desired-state map is rolled back.
+func TestUpsertExecutor_TransientRetainsLastKnownGood(t *testing.T) {
 	mgr := executorManager{
 		opts:        map[string]e.ScopedOptions{},
 		generations: map[string]int64{},
@@ -245,44 +283,27 @@ func TestUpsertExecutor_StaleRetainedAndNoOptsPollutionOnInvalidUpdate(t *testin
 	if goodExecutor == nil {
 		t.Fatalf("expected non-nil executor after initial upsert")
 	}
-	if got := mgr.opts[createOptsKey("default", "exec1")].Scopes[0]; got != "example.com" {
-		t.Fatalf("expected stored scope example.com, got %q", got)
-	}
 
-	// Update exec1 to an invalid config (generation advanced).
+	// Re-reconcile the SAME generation but the build now fails (transient).
 	broken := newInvalidExecutor()
-	broken.Generation = 2
+	broken.Generation = 1
 	if err := mgr.upsertExecutor("default", "exec1", broken); err == nil {
-		t.Fatalf("expected error when updating to an invalid config")
+		t.Fatalf("expected error on transient build failure")
 	}
 
-	// Last-known-good executor must be retained.
+	// Last-known-good executor must be retained (graceful degradation).
 	if mgr.GetExecutor() != goodExecutor {
-		t.Fatalf("expected the last-known-good executor to be retained after a failed update")
+		t.Fatalf("expected the last-known-good executor to be retained on a transient failure")
 	}
-
-	// m.opts must be rolled back to the previous valid config (no pollution).
-	if got := mgr.opts[createOptsKey("default", "exec1")].Scopes[0]; got != "example.com" {
-		t.Fatalf("expected opts to be rolled back to example.com, got %q", got)
-	}
-	// The last applied generation must remain the previous (successful) one.
-	if got := mgr.generations[createOptsKey("default", "exec1")]; got != 1 {
-		t.Fatalf("expected tracked generation to remain 1, got %d", got)
-	}
-
-	// A different, valid Executor must still be applicable (the broken CRD did
-	// not get stuck in m.opts and block unrelated reconciles).
-	other := newValidExecutor()
-	other.Spec.Scopes = []string{"other.com"}
-	other.Generation = 1
-	if err := mgr.upsertExecutor("default", "exec2", other); err != nil {
-		t.Fatalf("expected unrelated valid upsert to succeed, got: %v", err)
+	// m.opts must be rolled back to the previous valid config.
+	if got := mgr.opts[createOptsKey("default", "exec1")].Verifiers[0].Type; got != mockVerifierType {
+		t.Fatalf("expected opts to roll back to the valid config, got verifier type %q", got)
 	}
 }
 
-// TestUpsertExecutor_InvalidColdStartNoExecutor verifies that when the very
+// TestUpsertExecutor_InvalidColdStartFailsClosed verifies that when the very
 // first (cold-start) config is invalid, no executor is served (fail-closed).
-func TestUpsertExecutor_InvalidColdStartNoExecutor(t *testing.T) {
+func TestUpsertExecutor_InvalidColdStartFailsClosed(t *testing.T) {
 	mgr := executorManager{
 		opts:        map[string]e.ScopedOptions{},
 		generations: map[string]int64{},
@@ -295,8 +316,5 @@ func TestUpsertExecutor_InvalidColdStartNoExecutor(t *testing.T) {
 	}
 	if mgr.GetExecutor() != nil {
 		t.Fatalf("expected no executor to be served on invalid cold start (fail-closed)")
-	}
-	if _, exists := mgr.opts[createOptsKey("default", "exec1")]; exists {
-		t.Fatalf("expected broken cold-start entry not to remain in opts")
 	}
 }


### PR DESCRIPTION
Fixes #2798

## Problem

When an `Executor` CRD is updated to a config that fails to build (e.g. a leaf cert in the trust store, an unregistered verifier type), `refreshExecutor()` returns early and **keeps serving the last-known-good executor with no signal**. The operator's change is silently not enforced on the data plane until the pod restarts.

Additionally, `m.opts` was overwritten with the broken config **before** the build. Because `refreshExecutor()` rebuilds one combined `ScopedExecutor` from all entries, one broken entry made **every subsequent reconcile of any other (valid) Executor fail too** — the manager got stuck until the bad CRD was fixed or deleted.

## Changes

1. **Roll back `m.opts` on build failure** — restore the previous entry (or delete a newly-added one) so a single broken config no longer pollutes the desired-state map or blocks unrelated Executor reconciles.

2. **Warn when a stale executor is retained** — using `metadata.generation` to distinguish the two failure classes the issue calls out:
   - **Spec actually changed** (generation advanced) but the build failed → `Error` log stating the updated config is **NOT enforced** on the data plane until corrected or restarted. This is the real enforcement gap.
   - **Generation unchanged** (re-reconcile / periodic resync, e.g. a transient Azure Key Vault blip) → `Info` log; retaining the cached executor is the intended graceful degradation.

3. **Track last-applied generation per resource** and clean it up on delete.

This is the minimal, low-risk slice of the issue's proposed direction (#1 no `m.opts` pollution, plus surfacing the enforcement gap). Full per-key executor isolation / fail-closed convergence is left as a follow-up.

## Tests

Added unit tests in `executormanager_test.go`:
- `TestUpsertExecutor_StaleRetainedAndNoOptsPollutionOnInvalidUpdate` — last-known-good executor retained, `m.opts` rolled back, tracked generation preserved, and an unrelated valid Executor still applies afterward.
- `TestUpsertExecutor_InvalidColdStartNoExecutor` — invalid first config fails closed (no executor served, no residual opts entry).

`go build`, `go vet`, `gofmt`, and the package unit tests all pass. (The Ginkgo envtest suite requires `setup-envtest` binaries and is unaffected by this change.)