### PR TITLE
chore: switch internal/logger to local v2 errors package

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -24,8 +24,8 @@ import (
 	logstash "github.com/bshuster-repo/logrus-logstash-hook"
 	dcontext "github.com/docker/distribution/context"
 	"github.com/google/uuid"
+	re "github.com/notaryproject/ratify/v2/errors"
 	icontext "github.com/notaryproject/ratify/v2/internal/context"
-	re "github.com/ratify-project/ratify/errors"
 	"github.com/sirupsen/logrus"
 )
 


### PR DESCRIPTION
## Summary
Switches the `internal/logger` package to import the local v2 `errors` package instead of the external `github.com/ratify-project/ratify/errors` module.

- `internal/logger/logger.go`: change the `re` import from `github.com/ratify-project/ratify/errors` to `github.com/notaryproject/ratify/v2/errors`

This is extracted as a standalone change from #2730 to keep the Alpha.2 cleanup reviewable in smaller pieces.

## Validation
- `go build ./internal/logger/...`
- `go vet ./internal/logger/...`
- `go test ./internal/logger/...` — pass