### PR TITLE
ci: use go-version 1.26 in scan-vulns workflow

### DIFF
--- a/.github/workflows/scan-vulns.yaml
+++ b/.github/workflows/scan-vulns.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: "1.26.4"
+          go-version: "1.26"
           check-latest: true
       - uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # v1.1.0
 


### PR DESCRIPTION
## Summary
Use the minor-version-only `go-version: "1.26"` for the govulncheck job in the scan-vulns workflow instead of pinning a specific patch release. This lets the workflow pick up the latest 1.26.x patch automatically.

- `.github/workflows/scan-vulns.yaml`: `1.26.4` → `1.26`

Extracted as a standalone change from #2730 to keep the Alpha.2 cleanup reviewable in smaller pieces.